### PR TITLE
Initial side-channel documents and library simulation of designated-arguments language feature

### DIFF
--- a/side-channels/Makefile
+++ b/side-channels/Makefile
@@ -1,0 +1,1 @@
+include ../common.mk

--- a/side-channels/Side-channels_proposal-hierarchy.md
+++ b/side-channels/Side-channels_proposal-hierarchy.md
@@ -1,7 +1,7 @@
 ---
 title: "Side Channels: Hierarchical Overview of Three Proposals"
 document: none
-date: <!-- $TimeStamp$ -->2025-06-06 17:00 EDT<!-- $ -->
+date: <!-- $TimeStamp$ -->2025-06-30 19:14 EDT<!-- $ -->
 audience: Internal
 author:
   - name: Pablo Halpern
@@ -13,37 +13,127 @@ toc-depth: 2
 Introduction
 ============
 
-Discussions of language support for allocators yielded three parts that
-can be proposed separately and where each part is dependent on the part
-before. <!-- lah: That (i.e., C depends on B, and B depends on A) is the opposite of the meaning of the last paragraph of this section. --> 
+Discussions of language support for allocators yielded three parts that can be
+proposed separately. The third part, *viral class properties*, is the end goal
+for allocator support in the language, but the other two features are useful in
+their own right, allowing us to make incremental progress rather than proposing
+one giant feature. Moreover, the first part, *named parameters*, is the easiest
+to sell and can, therefore, help us develop momentum for the whole package of
+proposals. Summarized below, each part is is dependent on the part before.
 
-- **Viral class properties** that cause extra parameter-like side channels to be added
-  automatically to every constructor and implicitly propagate them to
-  containing objects (including compiler-generated types such as lambda
-  closures and arrays) <!-- lah: If you just say what you mean (parameter-like side channels), then you don't have to explain why you put "parameters" quotes. -->
+- After some discussion, we determined that **named parameters** would be the
+  most straightforward way to bind arguments to special parameters such as
+  allocators. Being a very general proposal, this feature should be easy to
+  sell to the Committee if we can overcome the issues that prevented similar
+  proposals from advancing in the past.
 
 - **Contextual default-argument values** (aka, _side-channel argument values_)
-  that automatically determine defaulted argument values from the caller's
+  would automatically determine defaulted argument values from the caller's
   context; e.g., if no explicit value is provided for the allocator parameter
-  in a member constructor, the parameter should get its value from the surrounding class's
-  allocator argument
+  in a member constructor, the parameter should get its value from the
+  surrounding class's allocator argument
 
-- A syntax for passing arguments that bind to these special parameters. After
-  some discussion, we determined that **named parameters** would be the most
-  straightforward way <!-- lah: way of what? --> and the easiest proposal to sell to the Committee.
+- **Viral class properties** would cause extra parameter side-channel
+  parameters to be added automatically to every constructor and implicitly
+  propagated to contained objects (including compiler-generated types such as
+  lambda closures and arrays).
 
-<!-- lah: The first two items are sentence fragments. The last one starts with a fragment and ends with a complete sentence. I recommend 
-writing them all as complete sentences so they are parallel. --> 
+Each feature is described in more below, but more detail will be forthcoming in
+a separate paper.
 
-The last feature needs to be completed before the one above, which in
-turn needs to be completed before the first feature. <!-- lah: This is the opposite of what was said in the first paragraph and says that B depends on C and A depends on B. --> 
-Each feature is
-briefly described below.
+Named Parameters
+================
+
+Until recently (May 2025), we thought that side channel arguments would
+be supplied by a syntax outside the argument list of a function,
+utilizing the using keyword:
+
+```cpp
+String hi("hello") using MyAllocator;
+```
+
+The advantage of this syntax is that the (usually optional) side channel
+does not pollute the argument list, obviating overload-disambiguation
+tricks, such as `allocator_arg_t`. After pursuing this approach for some
+time, we realized that this syntax could be used as a hacky
+way to get the benefits of named parameters and that named parameters
+would be a more natural way to express the intent:
+
+```cpp
+String hi("hello", .allocator = MyAllocator);
+```
+
+Unlike a regular (positional) parameter, a named parameter can be added
+to any function, even one that has default arguments or a variadic
+parameter list, without creating overloading or call-site ambiguities:
+
+**Without a named allocator argument:**
+
+```cpp
+template <class... Args>
+string foo(int i=0, std::pmr::polymorphic_allocator<> alloc={});
+
+auto s1 = foo();           // OK: i = 0, alloc = {}
+auto s2 = foo(3);          // OK: i = 3, alloc = {}
+auto s3 = foo(3, MyAlloc); // OK: i = 3, alloc = MyAlloc
+auto s4 = foo(MyAlloc);    // Error: No match
+```
+
+**With a named allocator argument (straw-man syntax):**
+
+```cpp
+template <class... Args>
+string bar(int i=0, std::pmr::polymorphic_allocator<> .allocator={});
+
+auto s5 = bar();                      // OK: i = 0, alloc = {}
+auto s6 = bar(3);                     // OK: i = 3, alloc = {}
+auto s7 = bar(3, .allocator=MyAlloc); // OK: i = 3, allocator = MyAlloc
+auto s8 = bar(.allocator = MyAlloc);  // OK: i = 0, allocator = MyAlloc
+```
+
+Developers
+have wanted named parameters in C++ for a long time, but
+we are unaware of any concerted effort to overcome the complexities of
+mixing named and positional arguments, overload resolution, pack
+expansion, pack indexing, and declaration/definition concurrence. We
+believe that we have a viable starting point that involves baking the
+named parameters into the function type, but we will need to
+research the previous failed efforts to avoid their mistakes.
+If we can overcome the technical obstacles, we think that WG21 will be
+interested in adding this feature to C++.
+
+Contextual Default-Argument Values
+==================================
+
+In the specific case of allocators, boilerplate code could be reduced if
+an object's constructor automatically passed its allocator argument to
+its allocator-aware subobjects. More generally, an invariant
+quality of certain arguments is that, in a function-call hierarchy, they
+should be automatically propagated from caller to callee. We have
+tentatively dubbed the arguments that participate in this automatic and
+invisible propagation _side-channel arguments_. When a value is not
+explicitly provided for a side channel, the side-channel argument should
+get its value by means of a mechanism that runs in the calling context and
+which can reflect on that context. Such reflection might need to
+determine whether the parameter is for a constructor, whether that
+constructor is for a full object or a subobject and for static vs. automatic
+storage duration, and/or whether the object is the return object of the
+calling function.
+
+Aside from allocators, such side-channel initialization would be useful
+for things like execution contexts and dynamically scoped variables,
+often replacing the use of global or thread-local variables, which make
+code difficult to reason about, can be inefficient, and can produce
+incorrect results in some cases (e.g., coroutines and other parallel agents
+that are distinct from threads).
+
+We do not yet have even a straw-man syntax for these special default-argument
+initializers.
 
 Viral Class Properties
 ======================
 
-The top-level goal that started this process was to provide allocator
+The top-level goal that started this process is to provide allocator
 support in the C++ language using a mechanism that would be generalized
 to other cross-cutting concerns, such as logging and execution contexts.
 We want to minimize the boilerplate code needed to pass around
@@ -74,97 +164,15 @@ struct Foo {
   int value;
 };
 ```
-<!-- lah: How is this file intended to be viewed? HTML? PDF? I'm seeing @** in the Markdown output, and I'm guessing that's not what you intended. --> 
+<!-- lah: How is this file intended to be viewed? HTML? PDF? I'm seeing @** in the Markdown output, and I'm guessing that's not what you intended.
+ pgh: We processes these documents using Michael Parks's Markdown dialect. The
+ '@' symbols let us embed Markdown into code sections.
+ -->
 
-Note that Foo uses the rule of zero, yet the automatically generated
+Note that `Foo` uses the rule of zero, yet the automatically generated
 constructors would still accept an allocator parameter. More than almost
 anything else, achieving the ability to apply to rule of zero to
 allocator-aware types is our fundamental goal.
-
-Contextual Default-Argument Values
-==================================
-
-In the specific case of allocators, boilerplate code could be reduced if
-an object's constructor automatically passed its allocator argument to
-its allocator-aware subobjects. More generally, an invariant
-quality of certain arguments is that, in a function-call hierarchy, they
-should be automatically propagated from caller to callee. We have
-tentatively dubbed the arguments that participate in this automatic and
-invisible propagation *side-channel arguments*. When a value is not
-explicitly provided for a side channel, the side-channel argument should
-get its value by means of a mechanism that runs in the calling context and
-which can reflect on that context. Such reflection might need to
-determine whether the parameter is for a constructor, whether that
-constructor is for a full object or a subobject and for static vs. automatic
-storage duration, and/or whether the object is the return object of the
-calling function.
-
-Aside from allocators, such side-channel initialization would be useful
-for things like execution contexts and dynamically scoped variables,
-often replacing the use of global or thread-local variables, which make
-code difficult to reason about, can be inefficient, and can produce
-incorrect results in some cases (e.g., coroutines and other parallel agents
-that are distinct from threads).
-
-We do not yet have even a straw-man syntax for these special
-initializers.
-
-Named Parameters
-================
-
-Until recently (May 2025), we thought that side channel arguments would
-be supplied by a syntax outside the argument list of a function,
-utilizing the using keyword:
-
-```cpp
-String hi("hello") using MyAllocator;
-```
-
-The advantage of this syntax is that the (usually optional) side channel
-does not pollute the argument list, obviating overload-disambiguation
-tricks, such as `allocator_arg_t`. After pursuing this approach for some
-time, we realized that this syntax could be used as a hacky <!-- lah: I like "hacky" as an adj. :)   --> 
-way to get the benefits of named parameters and that named parameters
-would be a more natural way to express the intent:
-
-```cpp
-String hi("hello", .allocator = MyAllocator);
-```
-
-Unlike a regular (positional) parameter, a named parameter can be added
-to any function, even one that has default arguments or a variadic
-parameter list, without creating overloading or call-site ambiguities:
-
-```cpp
-// without named allocator argument
-template <class... Args>
-string foo(int i=0, std::pmr::polymorphic_allocator<> alloc={});
-
-// with named allocator argument (straw-man syntax)
-template <class... Args>
-string bar(int i=0, std::pmr::polymorphic_allocator<> .allocator={});
-
-auto s1 = foo();           // OK: i = 0, alloc = {}
-auto s2 = foo(3);          // OK: i = 3, alloc = {}
-auto s3 = foo(3, MyAlloc); // OK: i = 3, alloc = MyAlloc
-auto s4 = foo(MyAlloc);    // Error: No match
-
-auto s5 = bar();                      // OK: i = 0, alloc = {}
-auto s6 = bar(3);                     // OK: i = 3, alloc = {}
-auto s7 = bar(3, .allocator=MyAlloc); // OK: i = 3, allocator = MyAlloc
-auto s8 = bar(.allocator = MyAlloc);  // OK: i = 0, allocator = MyAlloc
-```
-
-People <!-- lah: Can we be more specific? Committee members? Developers? Programmers? Engineers? Users? --> 
-have wanted to add named parameters to C++ for a long time, but
-we are unaware of any concerted effort to overcome the complexities of
-mixing named and positional arguments, overload resolution, pack
-expansion, pack indexing, and declaration/definition concurrence. We
-believe that we have a viable starting point that involves baking the
-named parameters into the function type, but we will need to
-research the previous failed efforts to avoid their mistakes.
-If we can overcome the technical obstacles, we think that WG21 will be
-interested in adding this feature to C++.
 
 Road Map
 ========
@@ -172,11 +180,10 @@ Road Map
 The viral-property proposal is dependent on the other two, and the contextual
 default-argument proposal is _probably_ dependent on the named-parameter
 proposal (e.g., if the syntax needs to refer to one of the caller's named
-arguments). <!-- lah: This meshes with the statement at the end of the intro, not the one at the beginning of the intro. --> 
-We should, therefore, pursue named parameters first, then
-side-channel arguments, then viral-class properties. This order is not only correct
-from a dependency standpoint but also starts from the most general proposal to
-the least general one, thus maximizing the chances of success. By the time we
-are ready to tackle viral annotations, the code-generation aspects of
-reflection are likely to be more developed, so
-this feature might even possibly be largely or completely implemented as a library feature.
+arguments).  We should, therefore, pursue named parameters first, then
+side-channel arguments, then viral-class properties. This order is not only
+correct from a dependency standpoint but also starts from the most general
+proposal to the least general one, thus maximizing the chances of success. By
+the time we are ready to tackle viral annotations, the code-generation aspects
+of reflection are likely to be more developed, so this feature might even
+possibly be largely or completely implemented as a library feature.

--- a/side-channels/Side-channels_proposal-hierarchy.md
+++ b/side-channels/Side-channels_proposal-hierarchy.md
@@ -1,0 +1,182 @@
+---
+title: "Side Channels: Hierarchical Overview of Three Proposals"
+document: none
+date: <!-- $TimeStamp$ -->2025-06-06 17:00 EDT<!-- $ -->
+audience: Internal
+author:
+  - name: Pablo Halpern
+    email: <phalpern@halpernwightsoftware.com>
+toc: true
+toc-depth: 2
+---
+
+Introduction
+============
+
+Discussions of language support for allocators yielded three parts that
+can be proposed separately and where each part is dependent on the part
+before. <!-- lah: That (i.e., C depends on B, and B depends on A) is the opposite of the meaning of the last paragraph of this section. --> 
+
+- **Viral class properties** that cause extra parameter-like side channels to be added
+  automatically to every constructor and implicitly propagate them to
+  containing objects (including compiler-generated types such as lambda
+  closures and arrays) <!-- lah: If you just say what you mean (parameter-like side channels), then you don't have to explain why you put "parameters" quotes. -->
+
+- **Contextual default-argument values** (aka, _side-channel argument values_)
+  that automatically determine defaulted argument values from the caller's
+  context; e.g., if no explicit value is provided for the allocator parameter
+  in a member constructor, the parameter should get its value from the surrounding class's
+  allocator argument
+
+- A syntax for passing arguments that bind to these special parameters. After
+  some discussion, we determined that **named parameters** would be the most
+  straightforward way <!-- lah: way of what? --> and the easiest proposal to sell to the Committee.
+
+<!-- lah: The first two items are sentence fragments. The last one starts with a fragment and ends with a complete sentence. I recommend 
+writing them all as complete sentences so they are parallel. --> 
+
+The last feature needs to be completed before the one above, which in
+turn needs to be completed before the first feature. <!-- lah: This is the opposite of what was said in the first paragraph and says that B depends on C and A depends on B. --> 
+Each feature is
+briefly described below.
+
+Viral Class Properties
+======================
+
+The top-level goal that started this process was to provide allocator
+support in the C++ language using a mechanism that would be generalized
+to other cross-cutting concerns, such as logging and execution contexts.
+We want to minimize the boilerplate code needed to pass around
+allocators (and loggers and execution contexts). Ideally,
+allocator-aware classes could follow the rule of zero, with the compiler
+automatically generating constructors that allow allocators to be passed
+in. A single annotation on a low-level type would indicate that such
+a type is allocator aware. The property established by the annotation
+would be viral such that a class having a member or base class of an
+allocator-aware type would itself automatically be allocator aware and
+thus have the appropriate allocator-passing mechanism available on every
+constructor. For example,
+
+```cpp
+class string @**allocator_aware**@ {
+ public:
+  // All constructors implicitly have a mechanism for being passed an allocator.
+  string();
+  string(const char *s);
+  string(const string&);
+  string(string&&);
+  // ...
+};
+
+// Foo is automatically @**allocator-aware**@ because it has a @**string**@ member.
+struct Foo {
+  string name;
+  int value;
+};
+```
+<!-- lah: How is this file intended to be viewed? HTML? PDF? I'm seeing @** in the Markdown output, and I'm guessing that's not what you intended. --> 
+
+Note that Foo uses the rule of zero, yet the automatically generated
+constructors would still accept an allocator parameter. More than almost
+anything else, achieving the ability to apply to rule of zero to
+allocator-aware types is our fundamental goal.
+
+Contextual Default-Argument Values
+==================================
+
+In the specific case of allocators, boilerplate code could be reduced if
+an object's constructor automatically passed its allocator argument to
+its allocator-aware subobjects. More generally, an invariant
+quality of certain arguments is that, in a function-call hierarchy, they
+should be automatically propagated from caller to callee. We have
+tentatively dubbed the arguments that participate in this automatic and
+invisible propagation *side-channel arguments*. When a value is not
+explicitly provided for a side channel, the side-channel argument should
+get its value by means of a mechanism that runs in the calling context and
+which can reflect on that context. Such reflection might need to
+determine whether the parameter is for a constructor, whether that
+constructor is for a full object or a subobject and for static vs. automatic
+storage duration, and/or whether the object is the return object of the
+calling function.
+
+Aside from allocators, such side-channel initialization would be useful
+for things like execution contexts and dynamically scoped variables,
+often replacing the use of global or thread-local variables, which make
+code difficult to reason about, can be inefficient, and can produce
+incorrect results in some cases (e.g., coroutines and other parallel agents
+that are distinct from threads).
+
+We do not yet have even a straw-man syntax for these special
+initializers.
+
+Named Parameters
+================
+
+Until recently (May 2025), we thought that side channel arguments would
+be supplied by a syntax outside the argument list of a function,
+utilizing the using keyword:
+
+```cpp
+String hi("hello") using MyAllocator;
+```
+
+The advantage of this syntax is that the (usually optional) side channel
+does not pollute the argument list, obviating overload-disambiguation
+tricks, such as `allocator_arg_t`. After pursuing this approach for some
+time, we realized that this syntax could be used as a hacky <!-- lah: I like "hacky" as an adj. :)   --> 
+way to get the benefits of named parameters and that named parameters
+would be a more natural way to express the intent:
+
+```cpp
+String hi("hello", .allocator = MyAllocator);
+```
+
+Unlike a regular (positional) parameter, a named parameter can be added
+to any function, even one that has default arguments or a variadic
+parameter list, without creating overloading or call-site ambiguities:
+
+```cpp
+// without named allocator argument
+template <class... Args>
+string foo(int i=0, std::pmr::polymorphic_allocator<> alloc={});
+
+// with named allocator argument (straw-man syntax)
+template <class... Args>
+string bar(int i=0, std::pmr::polymorphic_allocator<> .allocator={});
+
+auto s1 = foo();           // OK: i = 0, alloc = {}
+auto s2 = foo(3);          // OK: i = 3, alloc = {}
+auto s3 = foo(3, MyAlloc); // OK: i = 3, alloc = MyAlloc
+auto s4 = foo(MyAlloc);    // Error: No match
+
+auto s5 = bar();                      // OK: i = 0, alloc = {}
+auto s6 = bar(3);                     // OK: i = 3, alloc = {}
+auto s7 = bar(3, .allocator=MyAlloc); // OK: i = 3, allocator = MyAlloc
+auto s8 = bar(.allocator = MyAlloc);  // OK: i = 0, allocator = MyAlloc
+```
+
+People <!-- lah: Can we be more specific? Committee members? Developers? Programmers? Engineers? Users? --> 
+have wanted to add named parameters to C++ for a long time, but
+we are unaware of any concerted effort to overcome the complexities of
+mixing named and positional arguments, overload resolution, pack
+expansion, pack indexing, and declaration/definition concurrence. We
+believe that we have a viable starting point that involves baking the
+named parameters into the function type, but we will need to
+research the previous failed efforts to avoid their mistakes.
+If we can overcome the technical obstacles, we think that WG21 will be
+interested in adding this feature to C++.
+
+Road Map
+========
+
+The viral-property proposal is dependent on the other two, and the contextual
+default-argument proposal is _probably_ dependent on the named-parameter
+proposal (e.g., if the syntax needs to refer to one of the caller's named
+arguments). <!-- lah: This meshes with the statement at the end of the intro, not the one at the beginning of the intro. --> 
+We should, therefore, pursue named parameters first, then
+side-channel arguments, then viral-class properties. This order is not only correct
+from a dependency standpoint but also starts from the most general proposal to
+the least general one, thus maximizing the chances of success. By the time we
+are ready to tackle viral annotations, the code-generation aspects of
+reflection are likely to be more developed, so
+this feature might even possibly be largely or completely implemented as a library feature.

--- a/side-channels/code/Makefile
+++ b/side-channels/code/Makefile
@@ -1,0 +1,1 @@
+include ../../common.mk

--- a/side-channels/code/designated_param_sim.h
+++ b/side-channels/code/designated_param_sim.h
@@ -5,17 +5,24 @@
  */
 
 #include <utility>
+#include <tuple>
 #include <type_traits>
 #include <concepts>
-#include <iostream>
 
 #include "type_list.h"
+
+// This implementation uses a gcc extension (also available in clang) that
+// allows string-UDL templates.  Disable warning about extension.
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wgnu-string-literal-operator-template"
+#endif
+
+namespace designated_params {
 
 // Used for template debugging.  `print<T> x;` will display an error message
 // that includes the name of `T`.
 template <class T> struct print;
-
-namespace designated_params {
+template <auto V> struct printv;
 
 /// Compile-time representation of a string used to designate a parameter or
 /// argument.  Two `designator_t` objects represent the same designator if they
@@ -56,6 +63,49 @@ struct is_designator<designator_t<C0, C...>> : std::true_type { };
 struct no_default_arg_t { };
 constexpr inline no_default_arg_t no_default_arg{};
 
+/// Trait has value `true` if `T` can bind to a temporary, i.e., if `T` is an
+/// rvalue reference or a const lvalue reference.
+template <class T>
+struct would_bind_to_temporary
+  : std::disjunction<std::is_same<T, T&&>, std::is_same<T, const T&>>
+{
+};
+
+template <class T>
+constexpr inline bool would_bind_to_temporary_v =
+  would_bind_to_temporary<T>::value;
+
+/// Metafunction has value `true` if a function having return type `To` can
+/// return a variable or expression of type `From` without creating a dangling
+/// reference to a materialized temporary object.
+///
+/// To evaluate to true, `From` must be convertible to `To` and, if `To` can
+/// bind to a temporary (i.e., it has type `const T&` or `T&&`) then at least
+/// one of the following must be hold:
+///
+///  1. `From` has a conversion operator to `To` OR
+///  2. `From` is a reference type having a non-user-defined conversion to `To`
+///
+/// Otherwise, evaluate to false.
+///
+/// Note that this metafunction does not detect "internal" dangling, such as an
+/// `operator T&` that returns a reference to a member variable or a
+/// constructor taking a reference parameter and holding on to the reference.
+template <class From, class To>
+struct can_return_without_dangling : std::bool_constant<
+  (std::is_convertible_v<From, To> &&
+   (! would_bind_to_temporary_v<To> ||
+    (requires (From&& x) { { x.operator To() }; }) ||
+    (std::is_reference_v<From> &&
+     std::is_convertible_v<std::remove_reference_t<From>*,
+                           std::remove_reference_t<To>*>))) >
+{
+};
+
+template <class From, class To>
+constexpr inline bool can_return_without_dangling_v =
+  can_return_without_dangling<From, To>::value;
+
 } // close namespace details
 
 /// Using this concept to constrain a template allows the use of `designator`
@@ -65,7 +115,7 @@ constexpr inline no_default_arg_t no_default_arg{};
 template <class D>
 concept designator = details::is_designator<D>::value;
 
-template <designator auto DesV> class designated_arg_factory;  // Forward decl
+template <designator auto DesV> struct designated_arg_factory;  // Forward decl
 
 /// Representation of a designated argument, i.e., a runtime value with a
 /// desginator.
@@ -74,7 +124,7 @@ class designated_arg
 {
   T&& m_arg;
   constexpr designated_arg(T&& arg) : m_arg(std::forward<T>(arg)) { }
-  friend class designated_arg_factory<DesV>;
+  friend struct designated_arg_factory<DesV>;
 public:
   static constexpr inline auto designator_v = DesV;
   using value_type                          = T;
@@ -83,7 +133,7 @@ public:
     : m_arg(std::forward<T>(rhs.m_arg)) { }
 
   /// Return the runtime value without the designator.
-  T&& get() && { return std::forward<T>(m_arg); }
+  T&& get() { return std::forward<T>(m_arg); }
 };
 
 /// Factory class template for generating a `designated_arg`.  Typically, an
@@ -110,99 +160,147 @@ struct is_designated_arg<designated_arg<DesV, T>> : std::true_type {};
 template <class Arg>
 constexpr inline bool is_designated_arg_v = is_designated_arg<Arg>::value;
 
-/// Representation of a designated parameter with optional default argument
-/// value.
-template <class T, auto DesV, bool IsPositional,
-          auto DefaultArg = details::no_default_arg>
+/// Representation of a possibly-designated parameter with optional default
+/// argument value. `DefaultArgSrc` is either the default argument value or a
+/// functor that generates the default argument value.
+template <class T, auto DesV, bool IsPositional, class DefaultArgT>
 requires (designator<decltype(DesV)> or DesV == details::null_designator)
-class designated_param_t
+class param
 {
-#if 0  // TBD remove if designated_param does not represent a runtime value
-  T&& m_value;
-#endif
+  DefaultArgT m_default_arg;
 
 public:
   static constexpr inline auto designator_v = DesV;
   using value_type                          = T;
-  using default_arg_t                       = decltype(DefaultArg);
 
   static constexpr inline bool is_designated =
     (designator_v != details::null_designator);
   static constexpr inline bool is_positional = IsPositional;
   static constexpr inline bool has_default_arg =
-    ! std::is_same_v<default_arg_t, details::no_default_arg_t>;
+    ! std::is_same_v<DefaultArgT, details::no_default_arg_t>;
 
-#if 0  // TBD remove if designated_param does not represent a runtime value
-  /// No default constructor unless there is a default argument value.
-  constexpr designated_param_t()
-  requires(! has_default_arg)  = delete;
+  /// Construct with no default argument.
+  constexpr param() requires(! has_default_arg) { }
 
-  /// Default constructor when the default argument is a constant value of
-  /// structural type convertible to `T`.
-  constexpr designated_param_t()
-    requires (std::is_convertible_v<default_arg_t, T>)
-    : m_value(std::forward<T>(DefaultArg)) { }
+  /// Construct with default argument.
+  /// Mandates that `DefaultArgT` either be convertible to `T` or be an
+  /// invocable whose return value is convertible to `T`.
+  constexpr explicit param(DefaultArgT&& da)
+    requires (std::is_convertible_v<DefaultArgT, T>)
+    : m_default_arg(std::forward<DefaultArgT>(da)) { }
 
-  /// Default constructor when the default argument is specified as a functor
-  /// returning a type convertible to `T`.
-  constexpr designated_param_t()
-    requires (std::is_convertible_v<std::invoke_result_t<default_arg_t>, T&&>)
-    : m_value(std::forward<T>(DefaultArg())) { }
+  constexpr explicit param(DefaultArgT&& da)
+    requires (std::is_convertible_v<std::invoke_result_t<DefaultArgT>, T>)
+    : m_default_arg(std::forward<DefaultArgT>(da))
+  {
+  }
 
-  /// Construct from a designated argument having the same designator as this
-  /// parameter.
-  template <class U = T>
-    // TBD: Allow non-reference conversion; this will require constructing a
-    // temporary `T` in a member buffer.
-    requires (std::is_convertible_v<U&, T&>)
-  constexpr designated_param_t(designated_arg<DesV, U>&& arg)  // IMPLICIT
-    : m_value(std::move(arg).get()) { }
+  /// Return the default argument stored in this parameter for cases where the
+  /// default argument is not a functor.
+  constexpr decltype(auto) default_arg() const
+    requires (std::is_convertible_v<DefaultArgT, T>) {
+    // TBD: Currently should not use this function if initializing a `T` would
+    // require materializing a temporary. Assert that is not the case.
+    static_assert(details::can_return_without_dangling_v<DefaultArgT, T>,
+                  "Not implemented. Default argument return would dangle.");
+    return m_default_arg;
+  }
 
-  /// Construct from a non-designated argument (if positional).
-  template <class U = T>
-    requires (std::is_convertible_v<U&, T&>)
-    // TBD: Allow non-reference conversion; this will require constructing a
-    // temporary `T` in a member buffer.
-  constexpr designated_param_t(U&& arg)                      // IMPLICIT
-    requires (IsPositional)
-    : m_value(std::forward<T>(arg)) { }
-
-  /// Return the value bound to this parameter.
-  T&& get() const { return std::forward<T>(m_value); }
-#endif // 0
+  /// Return the default argument stored in this parameter for cases where the
+  /// default argument is a functor.
+  constexpr decltype(auto) default_arg() const
+    requires (std::is_convertible_v<std::invoke_result_t<DefaultArgT>, T>) {
+    using DAResult = std::invoke_result_t<DefaultArgT>;
+    // TBD: Currently should not use this function if initializing a `T` would
+    // require materializing a temporary. Assert that is not the case.
+    static_assert(details::can_return_without_dangling_v<DAResult, T>,
+                  "Not implemented. Default argument return would dangle.");
+    return m_default_arg();
+  }
 };
 
-/// Abbreviation for apositional non-designated parameter.
-template <class T, auto DefaultArg = details::no_default_arg>
-using pp = designated_param_t<T, details::null_designator, true, DefaultArg>;
+/// Factory functions for generating `param` instances:
+///  pp<T>(...)  returns a positional parameter. A designator and/or default
+///              argument can be optionally specified.
+///  npp<T>(...) returns a nonpositional parameter. A designator is required, a
+///              default argument can be optionally specified.
 
-/// Abbreviation for a positional designated parameter.
-template <class T, designator auto DesV,
-          auto DefaultArg = details::no_default_arg>
-using dpp = designated_param_t<T, DesV, true, DefaultArg>;
+/// Return a nondesignated positional parameter.
+template <class T>
+constexpr
+param<T, details::null_designator, true, details::no_default_arg_t> pp()
+{
+  return {};
+}
 
-/// Abbreviation for a non-positional designated parameter.
-template <class T, designator auto DesV,
-          auto DefaultArg = details::no_default_arg>
-using dp = designated_param_t<T, DesV, false, DefaultArg>;
+/// Return a nondesignated positional parameter with default argument.
+template <class T, class DefArg>
+constexpr param<T, details::null_designator, true, DefArg> pp(DefArg&& da)
+{
+  using ret_type = param<T, details::null_designator, true, DefArg>;
+  return ret_type(std::forward<DefArg>(da));
+}
+
+/// Return a designated positional parameter.
+template <class T, designator DesT>
+constexpr param<T, DesT{}, true, details::no_default_arg_t> pp(DesT)
+{
+  return {};
+}
+
+/// Return a designated positional parameter with default argument.
+template <class T, designator DesT, class DefArg>
+constexpr param<T, DesT{}, true, DefArg> pp(DesT, DefArg&& da)
+{
+  using ret_type = param<T, DesT{}, true, DefArg>;
+  return ret_type(std::forward<DefArg>(da));
+}
+
+/// Return a designated nonpositional parameter.
+template <class T, designator DesT>
+constexpr param<T, DesT{}, false, details::no_default_arg_t> npp(DesT)
+{
+  return {};
+}
+
+/// Return a designated nonpositional parameter with default argument.
+template <class T, designator DesT, class DefArg>
+constexpr param<T, DesT{}, false, DefArg> npp(DesT, DefArg&& da)
+{
+  using ret_type = param<T, DesT{}, false, DefArg>;
+  return ret_type(std::forward<DefArg>(da));
+}
 
 namespace details {
 
 template <class T>
 struct  has_no_default : std::true_type { };
 
-template <class T, auto DesV, bool IsPositional, auto DefaultArg>
-struct  has_no_default<designated_param_t<T, DesV, IsPositional, DefaultArg>>
-  : std::is_same<decltype(DefaultArg), no_default_arg_t>::type
+template <class T>
+struct  has_no_default<const T> : has_no_default<T>::type { };
+
+template <class T, auto DesV, bool IsPositional, class DefaultArgT>
+struct  has_no_default<param<T, DesV, IsPositional, DefaultArgT>>
+  : std::is_same<DefaultArgT, no_default_arg_t>::type
 {
 };
 
 /// Nested template
+template <auto DesV, class T>
+struct match_des_apply : std::false_type { };
+
+template <auto DesV, class T>
+requires requires { T::designator_v; }
+struct match_des_apply<DesV, T>
+{
+  using type = std::bool_constant<DesV == T::designator_v>;
+};
+
 template <auto DesV>
 struct match_des
 {
   template <class T>
-  struct apply : std::bool_constant<DesV == T::designator_v> {};
+  struct apply : match_des_apply<DesV, T>::type { };
 };
 
 /// Match the designated arguments in the `Args` list to the parameters in
@@ -285,22 +383,93 @@ consteval bool match_pa()
   }
 }
 
+template <size_t index, class Param, class... Args>
+constexpr decltype(auto) arg_lookup(const Param& p, std::tuple<Args...>& args)
+{
+  using arg_type_list = type_list<std::remove_reference_t<Args>...>;
+
+  if constexpr (index < type_list_find_v<arg_type_list, is_designated_arg>) {
+    // Positional parameter matches non-designated (positional) argument having
+    // the same index.
+    return std::get<index>(args);
+  }
+  else if constexpr (Param::is_designated) {
+    // Positional parameter matches designated argument by name.
+    constexpr std::size_t arg_idx =
+      type_list_find_v<arg_type_list,
+                       match_des<Param::designator_v>::template apply>;
+    if constexpr (arg_idx < arg_type_list::size()) {
+      return std::get<arg_idx>(args).get();
+    }
+    else {
+      // No match, return default argument value
+      return p.default_arg();
+    }
+  }
+  else {
+    // No match, return default argument value
+    return p.default_arg();
+  }
+}
 
 } // close namespace details
 
+/// Representation of a function signature.
 template <class... Params>
 class func_signature
 {
+  // TBD: use static_assert to validate that Params... is a valid set.
+
+  using param_values = std::tuple<typename Params::value_type...>;
+
+  std::tuple<Params...> m_params;
+
+  template <std::size_t... indexes, class ArgTuple>
+  constexpr param_values
+  get_param_values_imp(std::index_sequence<indexes...>, ArgTuple& args) const
+  {
+    return param_values(details::arg_lookup<indexes>(std::get<indexes>(m_params),
+                                                     args)...);
+  }
+
 public:
-  /// Return true if this is a viable function (each argument matches a
-  /// parameter and each parameter either matches an argument or has a default
-  /// value).
+  /// Construct from a set of parameters.
+  /// `ParamArgs` needs to be pretty much the same as `Params` but is a
+  /// template parmeter so as to deduce lvalue/rvalue category.
+  template <class... ParamArgs>
+  requires (sizeof...(ParamArgs) == sizeof...(Params))
+  constexpr func_signature(ParamArgs&&... pa)
+    : m_params(std::forward<ParamArgs>(pa)...) { }
+
+  /// Return true if this is a viable function for the specified argument list.
+  /// A function is viable if each argument matches a parameter and each
+  /// parameter either matches an argument or has a default value. If an
+  /// argument is not convertible to the parameter type, it is not considered a
+  /// match.
   /// Mandates: `Params...` has been validated as being in valid.
   template <class... Args>
   consteval bool is_viable() const {
     return details::match_pa<type_list<Params...>, type_list<Args...>>();
   }
+
+  /// Bind the specified `args` to the formal parameters. The returned `tuple`
+  /// is suitable for structured binding to local variables.
+  template <class... Args>
+  constexpr param_values get_param_values(Args&&... args) const
+  {
+    auto arg_tuple = std::forward_as_tuple(std::forward<Args>(args)...);
+    using indexes  = std::make_index_sequence<sizeof...(Params)>;
+    return get_param_values_imp(indexes{}, arg_tuple);
+  }
 };
+
+/// Deduction guide for `func_signature`.  Note that, since `Params...` is a
+/// pack of `param` objects that wrap the actual parameter types, removing
+/// references from `Params` does not affect the real parameter types in the
+/// signature.
+template <class... Params>
+func_signature(Params&&... p) ->
+  func_signature<std::remove_reference_t<Params>...>;
 
 namespace literals {
 

--- a/side-channels/code/designated_param_sim.h
+++ b/side-channels/code/designated_param_sim.h
@@ -1,0 +1,325 @@
+/* designated_param_sim.cpp                                           -*-C++-*-
+ *
+ * Copyright (C) 2024 Pablo Halpern <phalpern@halpernwightsoftware.com>
+ * Distributed under the Boost Software License - Version 1.0
+ */
+
+#include <utility>
+#include <type_traits>
+#include <concepts>
+#include <iostream>
+
+#include "type_list.h"
+
+// Used for template debugging.  `print<T> x;` will display an error message
+// that includes the name of `T`.
+template <class T> struct print;
+
+namespace designated_params {
+
+/// Compile-time representation of a string used to designate a parameter or
+/// argument.  Two `designator_t` objects represent the same designator if they
+/// have the same type.  A constexpr object of type `designator_t` is typically
+/// generated using the `_des` UDL in the `literals` namespace, below.
+template <char...>
+struct designator_t
+{
+  template <class Des2>
+  friend constexpr bool operator==(designator_t, Des2)
+    { return std::is_same_v<designator_t, Des2>; }
+
+  template <class Des2>
+  friend constexpr bool operator!=(designator_t d1, Des2 d2)
+    { return ! (d1 == d2); }
+};
+
+template <char... C>
+constexpr inline designator_t<C...> designator_v{};
+
+namespace details {
+
+/// Designator placeholder for non-designated types.
+constexpr inline designator_t<> null_designator{};
+
+/// Type trait evaluating to `true_type` if `T` is a specialization of
+/// `designator_t`. Primary template evalutes to `false_type`.
+template <class T>
+struct is_designator : std::false_type { };
+
+/// Partial specialization for `designator_t` evaluates to `true_type`.
+/// Note that a `designator_t` having zero characters (i.e., the
+/// type of `null_designator`) is not considered a designator by this trait.
+template <char C0, char... C>
+struct is_designator<designator_t<C0, C...>> : std::true_type { };
+
+/// Placeholder argument for parameter having no default argument.
+struct no_default_arg_t { };
+constexpr inline no_default_arg_t no_default_arg{};
+
+} // close namespace details
+
+/// Using this concept to constrain a template allows the use of `designator`
+/// as though it were a concrete type, i.e., `designator Des` specifies that
+/// `D` is a specialization of `designator_t`, where its (immutable,
+/// compile-time) value is carried by its type.
+template <class D>
+concept designator = details::is_designator<D>::value;
+
+template <designator auto DesV> class designated_arg_factory;  // Forward decl
+
+/// Representation of a designated argument, i.e., a runtime value with a
+/// desginator.
+template <designator auto DesV, class T>
+class designated_arg
+{
+  T&& m_arg;
+  constexpr designated_arg(T&& arg) : m_arg(std::forward<T>(arg)) { }
+  friend class designated_arg_factory<DesV>;
+public:
+  static constexpr inline auto designator_v = DesV;
+  using value_type                          = T;
+
+  constexpr designated_arg(const designated_arg& rhs)
+    : m_arg(std::forward<T>(rhs.m_arg)) { }
+
+  /// Return the runtime value without the designator.
+  T&& get() && { return std::forward<T>(m_arg); }
+};
+
+/// Factory class template for generating a `designated_arg`.  Typically, an
+/// object of this class is created using the `_arg` UDL in the literal
+/// namespace, below. For example `"value"_arg(3.2)` will create a
+/// `designated_arg` having designator "value" and value 3.2. There are
+/// actually two objects generated: an empty `designated_arg_factory` with
+/// designator "value", which is used to generate a `designated_arg` holding
+/// a `double` having value 3.2.
+template <designator auto DesV>
+struct designated_arg_factory
+{
+  template <class T>
+  constexpr designated_arg<DesV, T&&> operator()(T&& value)
+    { return std::forward<T>(value); }
+};
+
+template <class Arg>
+struct is_designated_arg : std::false_type {};
+
+template <auto DesV, class T>
+struct is_designated_arg<designated_arg<DesV, T>> : std::true_type {};
+
+template <class Arg>
+constexpr inline bool is_designated_arg_v = is_designated_arg<Arg>::value;
+
+/// Representation of a designated parameter with optional default argument
+/// value.
+template <class T, auto DesV, bool IsPositional,
+          auto DefaultArg = details::no_default_arg>
+requires (designator<decltype(DesV)> or DesV == details::null_designator)
+class designated_param_t
+{
+#if 0  // TBD remove if designated_param does not represent a runtime value
+  T&& m_value;
+#endif
+
+public:
+  static constexpr inline auto designator_v = DesV;
+  using value_type                          = T;
+  using default_arg_t                       = decltype(DefaultArg);
+
+  static constexpr inline bool is_designated =
+    (designator_v != details::null_designator);
+  static constexpr inline bool is_positional = IsPositional;
+  static constexpr inline bool has_default_arg =
+    ! std::is_same_v<default_arg_t, details::no_default_arg_t>;
+
+#if 0  // TBD remove if designated_param does not represent a runtime value
+  /// No default constructor unless there is a default argument value.
+  constexpr designated_param_t()
+  requires(! has_default_arg)  = delete;
+
+  /// Default constructor when the default argument is a constant value of
+  /// structural type convertible to `T`.
+  constexpr designated_param_t()
+    requires (std::is_convertible_v<default_arg_t, T>)
+    : m_value(std::forward<T>(DefaultArg)) { }
+
+  /// Default constructor when the default argument is specified as a functor
+  /// returning a type convertible to `T`.
+  constexpr designated_param_t()
+    requires (std::is_convertible_v<std::invoke_result_t<default_arg_t>, T&&>)
+    : m_value(std::forward<T>(DefaultArg())) { }
+
+  /// Construct from a designated argument having the same designator as this
+  /// parameter.
+  template <class U = T>
+    // TBD: Allow non-reference conversion; this will require constructing a
+    // temporary `T` in a member buffer.
+    requires (std::is_convertible_v<U&, T&>)
+  constexpr designated_param_t(designated_arg<DesV, U>&& arg)  // IMPLICIT
+    : m_value(std::move(arg).get()) { }
+
+  /// Construct from a non-designated argument (if positional).
+  template <class U = T>
+    requires (std::is_convertible_v<U&, T&>)
+    // TBD: Allow non-reference conversion; this will require constructing a
+    // temporary `T` in a member buffer.
+  constexpr designated_param_t(U&& arg)                      // IMPLICIT
+    requires (IsPositional)
+    : m_value(std::forward<T>(arg)) { }
+
+  /// Return the value bound to this parameter.
+  T&& get() const { return std::forward<T>(m_value); }
+#endif // 0
+};
+
+/// Abbreviation for apositional non-designated parameter.
+template <class T, auto DefaultArg = details::no_default_arg>
+using pp = designated_param_t<T, details::null_designator, true, DefaultArg>;
+
+/// Abbreviation for a positional designated parameter.
+template <class T, designator auto DesV,
+          auto DefaultArg = details::no_default_arg>
+using dpp = designated_param_t<T, DesV, true, DefaultArg>;
+
+/// Abbreviation for a non-positional designated parameter.
+template <class T, designator auto DesV,
+          auto DefaultArg = details::no_default_arg>
+using dp = designated_param_t<T, DesV, false, DefaultArg>;
+
+namespace details {
+
+template <class T>
+struct  has_no_default : std::true_type { };
+
+template <class T, auto DesV, bool IsPositional, auto DefaultArg>
+struct  has_no_default<designated_param_t<T, DesV, IsPositional, DefaultArg>>
+  : std::is_same<decltype(DefaultArg), no_default_arg_t>::type
+{
+};
+
+/// Nested template
+template <auto DesV>
+struct match_des
+{
+  template <class T>
+  struct apply : std::bool_constant<DesV == T::designator_v> {};
+};
+
+/// Match the designated arguments in the `Args` list to the parameters in
+/// `Params`. The number of unconsumed parameters having no default values is
+/// passed in `paramsLeft`. Return `false` if an argument is not matched to a
+/// parameter or if, after recursing `paramsLeft` does not go down to zero.
+template <class Params, class Args>
+consteval bool match_da(std::size_t paramsLeft)
+{
+  if constexpr (0 == Args::size()) {
+    return (0 == paramsLeft);  // Succeed if all parameters were matched
+  }
+  else {
+    static constexpr std::size_t param_idx =
+      type_list_find_v<Params,
+                       match_des<Args::head::designator_v>::template apply>;
+    if constexpr (param_idx >= Params::size()) {
+      // Did not find a parameter with the same designator.
+      // TBD: Match variadic param here.
+      return false;
+    }
+    else if constexpr (std::is_convertible_v<
+                         typename Args::head::value_type,
+                         typename type_list_element_t<param_idx,
+                                                      Params>::value_type
+                       >)
+    {
+      // Matched one designated argument with one designated parameter,
+      // including convertability of the value type.  Recurse on remaining
+      // arguments.
+
+      // If the matched parameter did not have a default argument, reduce the
+      // count of unmatched parameters by one.
+      paramsLeft -=
+        type_list_element_t<param_idx, Params>::has_default_arg ? 0 : 1;
+      return match_da<Params, typename Args::tail>(paramsLeft);
+    }
+    else {
+      // Found matching designator, but convertibility test failed.
+      return false;
+    }
+  }
+}
+
+/// Match the designated arguments in the `Args` list to the parameters in
+/// `Params`. Return `false` if an argument is not matched to a
+/// parameter or if, after recursing there are unmatched parameters not having
+/// default argument values.
+template <class Params, class Args>
+consteval bool match_da()
+{
+  // Count number of designated params left that don't have default arg then
+  // call a recursive function to process the remaining args.
+  return match_da<Params, Args>(type_list_count_v<Params, has_no_default>);
+}
+
+/// Match the undesignated positional arguments in the `Args` list to the
+/// corresponding `Params`.  Return `false` if there's a mismtach; otherwise,
+/// pass the remaining arguments and parameters to `match_dp`.
+template <class Params, class Args>
+consteval bool match_pa()
+{
+  if constexpr (0 == Args::size()) {
+    // No more arguments
+    return match_da<Params, Args>();
+  }
+  else if constexpr (is_designated_arg_v<typename Args::head>) {
+    // No more positional arguments
+    return match_da<Params, Args>();
+  }
+  else if constexpr (std::is_convertible_v<typename Args::head,
+                                           typename Params::head::value_type>){
+    // Matched one argument to one parameter; now match the rest, recursively.
+    return match_pa<typename Params::tail, typename Args::tail>();
+  }
+  // TBD: Match variadic param here
+  else {
+    // Missmatch
+    return false;
+  }
+}
+
+
+} // close namespace details
+
+template <class... Params>
+class func_signature
+{
+public:
+  /// Return true if this is a viable function (each argument matches a
+  /// parameter and each parameter either matches an argument or has a default
+  /// value).
+  /// Mandates: `Params...` has been validated as being in valid.
+  template <class... Args>
+  consteval bool is_viable() const {
+    return details::match_pa<type_list<Params...>, type_list<Args...>>();
+  }
+};
+
+namespace literals {
+
+// UDLs
+
+/// UDL for a designator
+template <class CharT, CharT... C>
+constexpr designator_t<C...> operator""_des() { return {}; }
+
+/// UDL to generate a designated argument.
+/// Example: `"ident"_arg(value)` generates a designated argument having the
+/// designator, "ident"_des, and the value, `value`.
+template <class CharT, CharT... C>
+constexpr designated_arg_factory<designator_v<C...>> operator""_arg()
+{ return {}; }
+
+} // close namespace literals
+} // close namespace designated_params
+
+// Local Variables:
+// c-basic-offset: 2
+// End:

--- a/side-channels/code/designated_param_sim.t.cpp
+++ b/side-channels/code/designated_param_sim.t.cpp
@@ -6,97 +6,319 @@
 
 #include <designated_param_sim.h>
 #include <string>
+#include <iostream>
+
+static int error_count = 0;
+
+void test_assert_failure(const char* file, int line, const char* expr)
+{
+  ++error_count;
+  std::cout << file << ':' << line << ": test assertion failed: " << expr
+            << std::endl;
+}
+
+#define TEST_ASSERT(C)                                                  \
+  if (C) (void) 0; else test_assert_failure(__FILE__, __LINE__, #C)
+
+#define TEST_EQ(V1, V2)                                         \
+  if ((V1) == (V2)) (void) 0;                                   \
+  else test_assert_failure(__FILE__, __LINE__, #V1 " == " #V2)
+
+#define TEST_SAME(T1, T2)                                               \
+  static_assert(std::is_same_v<T1, T2>,                                 \
+                "Types " #T1 " and " #T2 " should be the same")
+
+#define TEST_TYPE_IS(VAL, T) TEST_SAME(decltype(VAL), T)
 
 namespace dp = designated_params;
 using namespace dp::literals;
 
+// Test `_des` UDL
 constexpr auto h = "hello"_des;
 constexpr auto x = "x"_des;
 
-int default_x = 14;  // Not a compile-time constant
+// extern function to suppress unused-variable warnings
+void suppress_test_warnings1()
+{
+  (void) h;
+  (void) x;
+}
 
 // Parameter declarations
-using xparam = dp::dp<int, "x"_des>;          // int .x
-using yparam = dp::dp<int&&, "y"_des, 5>;     // int&& .y = 5
-using pp1    = dp::pp<double>;                // double a
-using pp2    = dp::pp<const char*, nullptr>;  // const char b = nullptr
-using zparam = dp::dpp<std::string, "z"_des,  // std::string .z = "hello"
-  [] -> std::string { return "hello"; }>;
+constexpr auto pp1    = dp::pp<const double&>();      // const double& a
+constexpr auto pp2    = dp::pp<const char*>(nullptr); // const char *b =nullptr
+constexpr auto xparam = dp::npp<int>("x"_des);        // int .x
+// TBD: Workound for inability to use default arguments that would materialize
+// temporaries when used.
+struct Five { operator int&&() const {
+  static int r = 5; return std::move(r); }
+} five;
+constexpr auto yparam = dp::npp<int&&>("y"_des, five);// int&& .y = 5
+//constexpr auto yparam = dp::npp<int&&>("y"_des, 5);   // int&& .y = 5
+constexpr auto zparam = dp::pp<std::string>("z"_des,  // string .z = "hello"
+  [] -> std::string { return "hello"; });
+
+using xparam_t = decltype(xparam);
+using yparam_t = decltype(yparam);
+using pp1_t    = decltype(pp1   );
+using pp2_t    = decltype(pp2   );
+using zparam_t = decltype(zparam);
 
 // Designated-argument types
-using xarg   = decltype("x"_arg(short(9)));   // .x = short(9)
-using nxarg  = decltype("x"_arg(nullptr));    // .x = nullptr
-using yarg   = decltype("y"_arg(99));         // .y = 99
-using zarg   = decltype("z"_arg("bye"));      // .z = "bye"
+auto xarg   = "x"_arg(short(9));   // .x = short(9)
+auto nxarg  = "x"_arg(nullptr);    // .x = nullptr
+auto yarg   = "y"_arg(99);         // .y = 99
+auto zarg   = "z"_arg("bye");      // .z = "bye"
+
+using xarg_t  = decltype(xarg );
+using nxarg_t = decltype(nxarg);
+using yarg_t  = decltype(yarg );
+using zarg_t  = decltype(zarg );
 
 // White-box incremental testing
 namespace test_details {
 
 using namespace dp::details;
 
+// test `can_return_without_dangling`
+struct B { };
+struct W : B { };
+struct X { operator       W()   const; };
+struct Y { operator const W&()  const; };
+struct Z { operator       W&&() const; };
+
+static_assert(  can_return_without_dangling_v<int, int>);
+static_assert(! can_return_without_dangling_v<int, int&>);
+static_assert(! can_return_without_dangling_v<int, const int&>);
+static_assert(! can_return_without_dangling_v<int, int&&>);
+static_assert(  can_return_without_dangling_v<W  , W  >);
+static_assert(  can_return_without_dangling_v<W  , B  >);
+static_assert(  std::is_convertible_v<W  , B  >);
+static_assert(  can_return_without_dangling_v<W& , B  >);
+static_assert(  can_return_without_dangling_v<W& , B& >);
+static_assert(  can_return_without_dangling_v<W& , const B&>);
+static_assert(  can_return_without_dangling_v<W&&, const B&>);
+static_assert(  can_return_without_dangling_v<X  , W  >);
+static_assert(! can_return_without_dangling_v<X  , const W&>);
+static_assert(! can_return_without_dangling_v<X  , W&&>);
+static_assert(  can_return_without_dangling_v<X& , W  >);
+static_assert(! can_return_without_dangling_v<X& , const W&>);
+static_assert(! can_return_without_dangling_v<X& , W&&>);
+static_assert(  can_return_without_dangling_v<X&&, W  >);
+static_assert(! can_return_without_dangling_v<X&&, const W&>);
+static_assert(! can_return_without_dangling_v<X&&, W&&>);
+static_assert(  can_return_without_dangling_v<Y  , W  >);
+static_assert(  can_return_without_dangling_v<Y  , const W&>);
+static_assert(! can_return_without_dangling_v<Y  , W&&>);
+static_assert(  can_return_without_dangling_v<Y& , W  >);
+static_assert(  can_return_without_dangling_v<Y& , const W&>);
+static_assert(! can_return_without_dangling_v<Y& , W&&>);
+static_assert(  can_return_without_dangling_v<Y&&, W  >);
+static_assert(  can_return_without_dangling_v<Y&&, const W&>);
+static_assert(! can_return_without_dangling_v<Y&&, W&&>);
+static_assert(  can_return_without_dangling_v<Z  , W  >);
+static_assert(! can_return_without_dangling_v<Z  , const W&>);
+static_assert(  can_return_without_dangling_v<Z  , W&&>);
+static_assert(  can_return_without_dangling_v<Z& , W  >);
+static_assert(! can_return_without_dangling_v<Z& , const W&>);
+static_assert(  can_return_without_dangling_v<Z& , W&&>);
+static_assert(  can_return_without_dangling_v<Z&&, W  >);
+static_assert(! can_return_without_dangling_v<Z&&, const W&>);
+static_assert(  can_return_without_dangling_v<Z&&, W&&>);
+
 // test `has_no_default`
-static_assert(  has_no_default<xparam>::value);
-static_assert(! has_no_default<yparam>::value);
+static_assert(  has_no_default<xparam_t>::value);
+static_assert(! has_no_default<yparam_t>::value);
 
 // test `match_des`
-static_assert(  match_des<"x"_des>::apply<xparam>::value);
-static_assert(  match_des<"y"_des>::apply<yparam>::value);
-static_assert(! match_des<"x"_des>::apply<yparam>::value);
+static_assert(  match_des<"x"_des>::apply<xparam_t>::value);
+static_assert(  match_des<"y"_des>::apply<yparam_t>::value);
+static_assert(! match_des<"x"_des>::apply<yparam_t>::value);
 
 // basic test for `match_da`
 static_assert(  match_da<type_list<>, type_list<>>());
-static_assert(! match_da<type_list<>, type_list<xarg>>());
-static_assert(! match_da<type_list<xparam>, type_list<>>());
-static_assert(  match_da<type_list<yparam>, type_list<>>());
-static_assert(  match_da<type_list<xparam>, type_list<xarg>>());
-static_assert(! match_da<type_list<xparam>, type_list<nxarg>>());
-static_assert(! match_da<type_list<xparam>, type_list<yarg>>());
-static_assert(! match_da<type_list<xparam, yparam>, type_list<yarg>>());
-static_assert(  match_da<type_list<xparam, yparam>, type_list<xarg>>());
-static_assert(  match_da<type_list<xparam, yparam>,
-                type_list<xarg, yarg>>());
-static_assert(! match_da<type_list<xparam, yparam>,
-              type_list<nxarg, yarg>>());
+static_assert(! match_da<type_list<>, type_list<xarg_t>>());
+static_assert(! match_da<type_list<xparam_t>, type_list<>>());
+static_assert(  match_da<type_list<yparam_t>, type_list<>>());
+static_assert(  match_da<type_list<xparam_t>, type_list<xarg_t>>());
+static_assert(! match_da<type_list<xparam_t>, type_list<nxarg_t>>());
+static_assert(! match_da<type_list<xparam_t>, type_list<yarg_t>>());
+static_assert(! match_da<type_list<xparam_t, yparam_t>, type_list<yarg_t>>());
+static_assert(  match_da<type_list<xparam_t, yparam_t>, type_list<xarg_t>>());
+static_assert(  match_da<type_list<xparam_t, yparam_t>,
+                type_list<xarg_t, yarg_t>>());
+static_assert(! match_da<type_list<xparam_t, yparam_t>,
+              type_list<nxarg_t, yarg_t>>());
 
 // test parameter list
-using params = type_list<pp1, pp2, zparam, xparam, yparam>;
+using params = type_list<pp1_t, pp2_t, zparam_t, xparam_t, yparam_t>;
 
 // basic test for `match_pa`
 static_assert(! match_pa<params, type_list<>>());
 static_assert(! match_pa<params, type_list<int>>());
 static_assert(  match_pa<params, type_list<int, const char(&)[4], const char*,
-                                           xarg, yarg>>());
+                                           xarg_t, yarg_t>>());
 static_assert(  match_pa<params, type_list<int, const char(&)[4],
-                                           xarg, yarg>>());
-static_assert(  match_pa<params, type_list<float, xarg, yarg, zarg>>());
-static_assert(  match_pa<params, type_list<float, yarg, xarg, zarg>>());
-static_assert(! match_pa<params, type_list<yarg, xarg, zarg>>());
-static_assert(! match_pa<params, type_list<float, yarg, zarg>>());
-static_assert(  match_pa<params, type_list<float, xarg, zarg>>());
+                                           xarg_t, yarg_t>>());
+static_assert(  match_pa<params, type_list<float, xarg_t, yarg_t, zarg_t>>());
+static_assert(  match_pa<params, type_list<float, yarg_t, xarg_t, zarg_t>>());
+static_assert(! match_pa<params, type_list<yarg_t, xarg_t, zarg_t>>());
+static_assert(! match_pa<params, type_list<float, yarg_t, zarg_t>>());
+static_assert(  match_pa<params, type_list<float, xarg_t, zarg_t>>());
+// The following should fail because argument `z` is specified both
+// positionally and designated.
 static_assert(! match_pa<params, type_list<int, const char(&)[4], const char*,
-                                           xarg, yarg, zarg>>()); // dup z
+                                           xarg_t, yarg_t, zarg_t>>());
 
 }
 
-constexpr auto params1 =
-  dp::func_signature<pp1, pp2, zparam, xparam, yparam>{};
+// constexpr auto params1 =
+//   dp::func_signature<pp1_t, pp2_t, zparam_t, xparam_t, yparam_t>{};
 
-static_assert(! params1.is_viable<>());
-static_assert(! params1.is_viable<int>());
-static_assert(  params1.is_viable<int, const char(&)[4], const char*,
-                                  xarg, yarg>());
-static_assert(  params1.is_viable<int, const char(&)[4], xarg, yarg>());
-static_assert(  params1.is_viable<float, xarg, yarg, zarg>());
-static_assert(  params1.is_viable<float, yarg, xarg, zarg>());
-static_assert(! params1.is_viable<yarg, xarg, zarg>());
-static_assert(! params1.is_viable<float, yarg, zarg>());
-static_assert(  params1.is_viable<float, xarg, zarg>());
-static_assert(! params1.is_viable<int, const char(&)[4], const char*,
-                                  xarg, yarg, zarg>()); // dup z
+// A function signature for testing.  First argument is the same as pp1, but
+// we need to test using an rvalue, which is more typical.
+constexpr dp::func_signature sig1 = {
+  dp::pp<const double&>(), pp2, zparam, xparam, yparam
+};
+
+static_assert(! sig1.is_viable<>());
+static_assert(! sig1.is_viable<int>());
+static_assert(  sig1.is_viable<int, const char(&)[4], const char*,
+                               xarg_t, yarg_t>());
+static_assert(  sig1.is_viable<int, const char(&)[4], xarg_t, yarg_t>());
+static_assert(  sig1.is_viable<float, xarg_t, yarg_t, zarg_t>());
+static_assert(  sig1.is_viable<float, yarg_t, xarg_t, zarg_t>());
+static_assert(! sig1.is_viable<yarg_t, xarg_t, zarg_t>());
+static_assert(! sig1.is_viable<float, yarg_t, zarg_t>());
+static_assert(  sig1.is_viable<float, xarg_t, zarg_t>());
+static_assert(! sig1.is_viable<int, const char(&)[4], const char*,
+                               xarg_t, yarg_t, zarg_t>()); // dup z
+
+/// Default `type_base_name` implementation uses `typeid`.
+template <class T>
+constexpr const char* base_type_name(const T&) { return typeid(T).name(); }
+
+// template <std::size_t SZ>
+// constexpr const char* base_type_name(const char(&)[SZ])
+// {
+//   return "const char[]";
+// }
+
+// This macro generates an overload of `base_type_name` that returns the string
+// "T" when invoked with an object of type `T`. The use of `type_identity`
+// treats `T` as a single type rather than a sequence of tokens, thus
+// preventing syntax errors when `T` is a complex type such as `const char*` or
+// `int []`.
+#define BASE_TYPE_NAME(T) \
+  constexpr const char* base_type_name(const std::type_identity_t<T>&) { return #T; }
+
+BASE_TYPE_NAME(char)
+BASE_TYPE_NAME(char*)
+BASE_TYPE_NAME(const char*)
+BASE_TYPE_NAME(short)
+BASE_TYPE_NAME(int)
+BASE_TYPE_NAME(long)
+BASE_TYPE_NAME(float)
+BASE_TYPE_NAME(double)
+BASE_TYPE_NAME(std::string)
+BASE_TYPE_NAME(std::nullptr_t)
+BASE_TYPE_NAME(char[])
+
+template <class T>
+void print_type_and_value(const T& v)
+{
+  std::cout << '(';
+  if constexpr (std::is_const_v<std::remove_reference_t<T>>)
+    std::cout << "const ";
+
+  std::cout << base_type_name(v);
+
+  if constexpr (std::is_lvalue_reference_v<T>)
+    std::cout << "&";
+  else if constexpr (std::is_rvalue_reference_v<T>)
+    std::cout << "&&";
+
+  std::cout << ") " << v << std::endl;
+}
+
+template <class T>
+void print_type_and_value(T&& v)
+{
+  print_type_and_value<T>(v);
+}
+
+#define PTV(V) do {                                                     \
+    std::cout << #V << " = "; print_type_and_value<decltype(V)>(V);     \
+  } while (false)
+
+
+template <class... Args>
+auto f1(Args&&... args) requires (sig1.is_viable<Args...>())
+{
+  auto [p1, p2, z, x, y] = sig1.get_param_values(std::forward<Args>(args)...);
+
+  TEST_TYPE_IS(p1, const double&);
+  TEST_TYPE_IS(p2, const char*);
+  TEST_TYPE_IS(z , std::string);
+  TEST_TYPE_IS(x , int);
+  TEST_TYPE_IS(y , int&&);
+
+#ifdef TRACE  // For debugging only
+  std::cout << "\nf1 argument values:\n";
+  PTV(p1);
+  PTV(p2);
+  PTV(z );
+  PTV(x );
+  PTV(y );
+#endif
+
+  return std::tuple{ p1, p2, z, x, y };
+}
 
 int main()
 {
+  {
+    double d = 1.2;
+    auto [p1, p2, z, x, y] = sig1.get_param_values(d, "a", "b",
+                                                   "y"_arg(99),
+                                                   "x"_arg(short(9)));
+
+    TEST_TYPE_IS(p1, const double&);
+    TEST_TYPE_IS(p2, const char*);
+    TEST_TYPE_IS(z , std::string);
+    TEST_TYPE_IS(x , int);
+    TEST_TYPE_IS(y , int&&);
+
+    d = 3.4;  // Ensure that the actual reference was captured
+    TEST_EQ(std::tuple(3.4, "a", "b", 9, 99), std::tuple(p1, p2, z, x, y));
+  }
+  {
+    constexpr double d = 1.2;
+    auto [p1, p2, z, x, y] = sig1.get_param_values(d, "a",
+                                                   "y"_arg(99),
+                                                   "x"_arg(short(9)));
+
+    TEST_TYPE_IS(p1, const double&);
+    TEST_TYPE_IS(p2, const char*);
+    TEST_TYPE_IS(z , std::string);
+    TEST_TYPE_IS(x , int);
+    TEST_TYPE_IS(y , int&&);
+
+    TEST_EQ(std::tuple(1.2, "a", "hello", 9, 99), std::tuple(p1, p2, z, x, y));
+  }
+
+  TEST_EQ(std::tuple(1.2, "a", "b", 9, 99),
+          f1(1.2,  "a", "b", "y"_arg(99), "x"_arg(short(9))));
+
+  TEST_EQ(std::tuple(3.4, "c", "hello", 8, 88),
+          f1(3.4,  "c", "x"_arg(short(8)), "y"_arg(88)));
+
+  TEST_EQ(std::tuple(5.6, "d", "bye", 7, 5),
+          f1(5.6,  "d", "x"_arg(7), "z"_arg("bye")));
+
+  return error_count;
 }
+
 
 // Local Variables:
 // c-basic-offset: 2

--- a/side-channels/code/designated_param_sim.t.cpp
+++ b/side-channels/code/designated_param_sim.t.cpp
@@ -1,0 +1,103 @@
+/* designated_param_sim.t.cpp                                         -*-C++-*-
+ *
+ * Copyright (C) 2024 Pablo Halpern <phalpern@halpernwightsoftware.com>
+ * Distributed under the Boost Software License - Version 1.0
+ */
+
+#include <designated_param_sim.h>
+#include <string>
+
+namespace dp = designated_params;
+using namespace dp::literals;
+
+constexpr auto h = "hello"_des;
+constexpr auto x = "x"_des;
+
+int default_x = 14;  // Not a compile-time constant
+
+// Parameter declarations
+using xparam = dp::dp<int, "x"_des>;          // int .x
+using yparam = dp::dp<int&&, "y"_des, 5>;     // int&& .y = 5
+using pp1    = dp::pp<double>;                // double a
+using pp2    = dp::pp<const char*, nullptr>;  // const char b = nullptr
+using zparam = dp::dpp<std::string, "z"_des,  // std::string .z = "hello"
+  [] -> std::string { return "hello"; }>;
+
+// Designated-argument types
+using xarg   = decltype("x"_arg(short(9)));   // .x = short(9)
+using nxarg  = decltype("x"_arg(nullptr));    // .x = nullptr
+using yarg   = decltype("y"_arg(99));         // .y = 99
+using zarg   = decltype("z"_arg("bye"));      // .z = "bye"
+
+// White-box incremental testing
+namespace test_details {
+
+using namespace dp::details;
+
+// test `has_no_default`
+static_assert(  has_no_default<xparam>::value);
+static_assert(! has_no_default<yparam>::value);
+
+// test `match_des`
+static_assert(  match_des<"x"_des>::apply<xparam>::value);
+static_assert(  match_des<"y"_des>::apply<yparam>::value);
+static_assert(! match_des<"x"_des>::apply<yparam>::value);
+
+// basic test for `match_da`
+static_assert(  match_da<type_list<>, type_list<>>());
+static_assert(! match_da<type_list<>, type_list<xarg>>());
+static_assert(! match_da<type_list<xparam>, type_list<>>());
+static_assert(  match_da<type_list<yparam>, type_list<>>());
+static_assert(  match_da<type_list<xparam>, type_list<xarg>>());
+static_assert(! match_da<type_list<xparam>, type_list<nxarg>>());
+static_assert(! match_da<type_list<xparam>, type_list<yarg>>());
+static_assert(! match_da<type_list<xparam, yparam>, type_list<yarg>>());
+static_assert(  match_da<type_list<xparam, yparam>, type_list<xarg>>());
+static_assert(  match_da<type_list<xparam, yparam>,
+                type_list<xarg, yarg>>());
+static_assert(! match_da<type_list<xparam, yparam>,
+              type_list<nxarg, yarg>>());
+
+// test parameter list
+using params = type_list<pp1, pp2, zparam, xparam, yparam>;
+
+// basic test for `match_pa`
+static_assert(! match_pa<params, type_list<>>());
+static_assert(! match_pa<params, type_list<int>>());
+static_assert(  match_pa<params, type_list<int, const char(&)[4], const char*,
+                                           xarg, yarg>>());
+static_assert(  match_pa<params, type_list<int, const char(&)[4],
+                                           xarg, yarg>>());
+static_assert(  match_pa<params, type_list<float, xarg, yarg, zarg>>());
+static_assert(  match_pa<params, type_list<float, yarg, xarg, zarg>>());
+static_assert(! match_pa<params, type_list<yarg, xarg, zarg>>());
+static_assert(! match_pa<params, type_list<float, yarg, zarg>>());
+static_assert(  match_pa<params, type_list<float, xarg, zarg>>());
+static_assert(! match_pa<params, type_list<int, const char(&)[4], const char*,
+                                           xarg, yarg, zarg>>()); // dup z
+
+}
+
+constexpr auto params1 =
+  dp::func_signature<pp1, pp2, zparam, xparam, yparam>{};
+
+static_assert(! params1.is_viable<>());
+static_assert(! params1.is_viable<int>());
+static_assert(  params1.is_viable<int, const char(&)[4], const char*,
+                                  xarg, yarg>());
+static_assert(  params1.is_viable<int, const char(&)[4], xarg, yarg>());
+static_assert(  params1.is_viable<float, xarg, yarg, zarg>());
+static_assert(  params1.is_viable<float, yarg, xarg, zarg>());
+static_assert(! params1.is_viable<yarg, xarg, zarg>());
+static_assert(! params1.is_viable<float, yarg, zarg>());
+static_assert(  params1.is_viable<float, xarg, zarg>());
+static_assert(! params1.is_viable<int, const char(&)[4], const char*,
+                                  xarg, yarg, zarg>()); // dup z
+
+int main()
+{
+}
+
+// Local Variables:
+// c-basic-offset: 2
+// End:

--- a/side-channels/code/type_list.h
+++ b/side-channels/code/type_list.h
@@ -1,0 +1,118 @@
+/* type_list.h                                                        -*-C++-*-
+ *
+ * Copyright (C) 2024 Pablo Halpern <phalpern@halpernwightsoftware.com>
+ * Distributed under the Boost Software License - Version 1.0
+ */
+
+#ifndef INCLUDED_TYPE_LIST_H
+#define INCLUDED_TYPE_LIST_H
+
+#include <utility>
+#include <cstdlib>
+
+// General-purpose typelist
+template <typename... T>
+struct type_list
+{
+  static constexpr std::size_t size() { return 0; }
+};
+
+template <typename T0, typename... T>
+struct type_list<T0, T...>
+{
+  static constexpr std::size_t size() { return 1 + sizeof...(T); }
+  using head = T0;
+  using tail = type_list<T...>;
+};
+
+/// Metafunction to get size of a type list
+template <class TL>
+constexpr inline std::size_t type_list_size_v = TL::size();
+
+/// Metafunction to get Nth element of a type list
+template <std::size_t N, class TL> struct type_list_element;
+
+template <std::size_t N, class... Types>
+struct type_list_element<N, type_list<Types...>>
+{
+#ifdef __clang__
+  using type = __type_pack_element<N, Types...>;
+#else
+  using type = typename std::_Nth_type<N, Types...>::type;
+#endif
+};
+
+template <std::size_t N, class TL>
+using type_list_element_t = typename type_list_element<N, TL>::type;
+
+// Metafunction for contcatonating two typelists
+template <typename TL1, typename TL2> struct type_list_concat;
+
+template <typename... T1, typename... T2>
+struct type_list_concat<type_list<T1...>, type_list<T2...>>
+{
+  using type = type_list<T1..., T2...>;
+};
+
+template <typename TL1, typename TL2>
+using type_list_concat_t = typename type_list_concat<TL1, TL2>::type;
+
+/// Metafunction to count the number of elements, E, in `TL` for which
+/// `Pred<E>::value` is true.
+template <typename TL, template <class T> class Pred>
+struct type_list_count
+{
+};
+
+template <typename... T , template <class U> class Pred>
+struct type_list_count<type_list<T...>, Pred>
+{
+  static constexpr inline std::size_t value = (Pred<T>::value + ... + 0);
+};
+
+template <typename TL, template <class T> class Pred>
+constexpr inline std::size_t type_list_count_v =
+  type_list_count<TL, Pred>::value;
+
+/// Metafunction to return the index of the first element, E, in `TL` for which
+/// `Pred<E>::value` is true.  Returns `TL::size() + 1` if E is not found.
+class __find_cell
+{
+  std::size_t m_idx   = 0;
+  bool        m_match = false;
+
+public:
+  constexpr std::size_t idx() { return m_idx; }
+
+  // Given a chain (fold) of `__find_cell || bool || bool || ...`, the final
+  // value of `idx()` will be the index of the first `true` value or, if there
+  // are none, the index of one-past-the-end (i.e., the length of the chain).
+  constexpr __find_cell&& operator||(bool rhs) &&
+  {
+    m_match = (m_match || rhs);
+    if (! m_match)
+      ++m_idx;
+    return std::move(*this);
+  }
+};
+
+template <typename TL, template <class U> class Pred>
+struct type_list_find;
+
+template <typename... T, template <class U> class Pred>
+struct type_list_find<type_list<T...>, Pred>
+{
+  // Fold expression returns `__find_cell` having a true `m_match`.
+  static constexpr inline std::size_t value =
+    (__find_cell{} || ... || Pred<T>::value).idx();
+};
+
+template <typename TL, template <class U> class Pred>
+constexpr inline std::size_t type_list_find_v =
+  type_list_find<TL, Pred>::value;
+
+#endif  // INCLUDED_TYPE_LIST_H
+
+// Local Variables:
+// c-basic-offset: 2
+// End:

--- a/side-channels/code/type_list.t.cpp
+++ b/side-channels/code/type_list.t.cpp
@@ -1,0 +1,115 @@
+/* type_list.t.cpp                                                    -*-C++-*-
+ *
+ * Copyright (C) 2024 Pablo Halpern <phalpern@halpernwightsoftware.com>
+ * Distributed under the Boost Software License - Version 1.0
+ */
+
+#include <type_list.h>
+
+#include <type_traits>
+#include <cassert>
+
+#define UNPAREN(...) UNPAREN_CLEANUP(UNPAREN_NORMALIZE __VA_ARGS__)
+
+// Whether invoked as `UNPAREN_NORMALIZE(ARGS, ...)` (with parentheses) or
+// `UNPAREN_NORMALIZE ARGS, ...` (without parentheses), the resulting
+// *normalized* expansion is `UNPAREN_NORMALIZE ARGS, ...`.  Note that the
+// second form is not actually a macro expansion but rather the result of *not*
+// expanding a function-like macro (because of the absence of parentheses).
+#define UNPAREN_NORMALIZE(...) UNPAREN_NORMALIZE __VA_ARGS__
+
+// Invoked as `UNPAREN_CLEANUP(UNPAREN_NORMALIZE ARGS, ...)` and expand it to
+// `UNPAREN_CLEANUP(UNPAREN_REMOVE_UNPAREN_NORMALIZE ARGS, ...)`, which, in
+// turn, expands to simply `ARGS, ...` (because
+// `UNPAREN_REMOVE_UNPAREN_NORMALIZE` expands to nothing).  The indirection
+// through `UNPAREN_CLEANUP2` is needed because the splice operator (`##`) is
+// eager and it is necessary to expand any macros within the argument list
+// before applying the splice.
+#define UNPAREN_CLEANUP(...) UNPAREN_CLEANUP2(__VA_ARGS__)
+#define UNPAREN_CLEANUP2(...) UNPAREN_REMOVE_ ## __VA_ARGS__
+
+// Expand to nothing.  This expression-like macro is "invoked" as
+// `UNPAREN_UNPAREN_NORMALIZE ARGS, ...` and leaves only `ARGS, ...`.
+#define UNPAREN_REMOVE_UNPAREN_NORMALIZE
+
+#define ASSERT_SAME(T1, ...) \
+  static_assert(std::is_same_v<UNPAREN(T1), __VA_ARGS__>)
+
+using EmptyTL = type_list<>;
+using TestTL  = type_list<char, unsigned short, unsigned, float>;
+
+// Test `type_list::size()`
+static_assert(0 == EmptyTL::size());
+static_assert(4 == TestTL::size());
+
+// Test `type_list::head` and `type_list::tail`
+ASSERT_SAME(TestTL::head, char);
+ASSERT_SAME(TestTL::tail, type_list<unsigned short, unsigned, float>);
+
+// Test `type_list_size` metafunction
+static_assert(0 == type_list_size_v<EmptyTL>);
+static_assert(4 == type_list_size_v<TestTL>);
+
+// Test `type_list_element` metafunction
+ASSERT_SAME(char          , type_list_element_t<0, TestTL>);
+ASSERT_SAME(unsigned short, type_list_element_t<1, TestTL>);
+ASSERT_SAME(unsigned int  , type_list_element_t<2, TestTL>);
+ASSERT_SAME(float         , type_list_element_t<3, TestTL>);
+
+// Test `type_list_concat` metafunction
+using TestTLSquared = type_list<char, unsigned short, unsigned, float,
+                                char, unsigned short, unsigned, float>;
+ASSERT_SAME(EmptyTL      , type_list_concat_t<EmptyTL, EmptyTL>);
+ASSERT_SAME(TestTL       , type_list_concat_t<TestTL , EmptyTL>);
+ASSERT_SAME(TestTL       , type_list_concat_t<EmptyTL, TestTL >);
+ASSERT_SAME(TestTLSquared, type_list_concat_t<TestTL , TestTL >);
+
+// Test `type_list_count`
+template <std::size_t SZ>
+struct size_test
+{
+  template <class T>
+  struct match
+  {
+    static constexpr inline bool value = (sizeof(T) == SZ);
+  };
+
+  template <class T>
+  struct at_least
+  {
+    static constexpr inline bool value = (sizeof(T) >= SZ);
+  };
+};
+
+static_assert(0 == type_list_count_v<EmptyTL, std::is_unsigned>);
+static_assert(2 == type_list_count_v<TestTL , std::is_unsigned>);
+static_assert(0 == type_list_count_v<EmptyTL, size_test<1>::match>);
+static_assert(1 == type_list_count_v<TestTL,  size_test<1>::match>);
+static_assert(1 == type_list_count_v<TestTL,  size_test<2>::match>);
+static_assert(2 == type_list_count_v<TestTL,  size_test<4>::match>);
+static_assert(0 == type_list_count_v<EmptyTL, size_test<1>::at_least>);
+static_assert(4 == type_list_count_v<TestTL,  size_test<1>::at_least>);
+static_assert(3 == type_list_count_v<TestTL,  size_test<2>::at_least>);
+static_assert(2 == type_list_count_v<TestTL,  size_test<4>::at_least>);
+
+static_assert(0 == type_list_find_v<EmptyTL, std::is_unsigned>);
+static_assert(0 == type_list_find_v<TestTL , std::is_signed>);
+static_assert(1 == type_list_find_v<TestTL , std::is_unsigned>);
+static_assert(0 == type_list_find_v<EmptyTL, size_test<1>::match>);
+static_assert(0 == type_list_find_v<TestTL,  size_test<1>::match>);
+static_assert(1 == type_list_find_v<TestTL,  size_test<2>::match>);
+static_assert(2 == type_list_find_v<TestTL,  size_test<4>::match>);
+static_assert(4 == type_list_find_v<TestTL,  size_test<5>::match>);
+static_assert(0 == type_list_find_v<EmptyTL, size_test<1>::at_least>);
+static_assert(0 == type_list_find_v<TestTL,  size_test<1>::at_least>);
+static_assert(1 == type_list_find_v<TestTL,  size_test<2>::at_least>);
+static_assert(2 == type_list_find_v<TestTL,  size_test<4>::at_least>);
+static_assert(4 == type_list_find_v<TestTL,  size_test<5>::at_least>);
+
+int main()
+{
+}
+
+// Local Variables:
+// c-basic-offset: 2
+// End:

--- a/side-channels/named-parameters.md
+++ b/side-channels/named-parameters.md
@@ -1,0 +1,955 @@
+---
+title: "Designated Parameters"
+document: named-parameters
+# $TimeStamp$
+date: 2025-08-11 11:40 EDT
+# $
+audience: LEWGI
+author:
+  - name: Pablo Halpern
+    email: <phalpern@halpernwightsoftware.com>
+  - name: Joshua Berne
+    email: <jberne4@bloomberg.net>
+working-draft: N5008
+toc: true
+toc-depth: 2
+---
+
+# Abstract
+
+Naming specific arguments at a function call site is supported in a number of
+popular programming languages, including Python, Swift, C#, Ada, and
+JavaScript, among others. This document describes how C++ can benefit from
+adopting a syntax for designating (named) parameters, provides a number of
+motivating use cases, and provides a proposed syntax and semantics for the
+proposed new designated-parameter feature. Though formal wording is not
+proposed at this time, we thoroughly explore how the new feature would interact
+with other aspects of C++, including overload resolution, template argument
+deduction, and the type system. We also explore why previous proposals in this
+area have failed and how this proposal overcomes the deficiencies of those
+earlier proposals. This proposal is in the exploratory phase and its target
+audience is EWGI.
+
+Note to early reviewers: This document started out as a collection of Pablo's
+musings but turned into something that is well on the way to being a complete
+proposal.
+
+# Motivation
+
+Existing languages that provide the ability to name arguments at a function
+call site (e.g., Python, Swift, and Ada), benefit from easier to read
+(self-documenting) function calls, resistance to certain common errors (such as
+out-of-order arguments), and easier-to-evolve function interfaces. Along with
+the benefits enjoyed by other languages, designated parameters would benefit C++ in
+ways peculiar to its syntactic weaknesses, such as potential overload
+ambiguities and constraints on default- and variadic-argument
+ordering. Additionally, designated parameters would make C++ more expressive by
+expanding the range of potential overloads and supporting cleaner idioms for
+generic programming.  Each of these benefits is described in detail in the
+[Motivating Use Cases](#motivating-use-cases) section, below.
+
+In the absence of designated parameters, programmers have devised a number of
+library-only techniques attempting to get some of the benefits of designated
+parameters in C++. The use of a `struct` parameter with designated initializers
+(see
+[Library Workaround Using Designated Aggregate Initializers](#library-workaround-using-designated-aggregate-initializers))
+makes calls easier to read, less error prone, and/or making the interface
+easier to evolve. Tagged parameters (see
+[Simpler Code Evolution and Fewer Overloads](#simpler-code-evolution-and-fewer-overloads))
+provide overload disambiguation and some measure of interface evolution. These
+techniques are ad-hoc, inconsistent with one another, don't resemble normal
+parameter declarations, and don't allow arguments to be reordered.
+
+# A Very Short Summary of the Proposal
+
+The syntax used in this document is not from fully baked; some alternatives are
+described in the
+[Alternative Syntax and Terminology](#alternative-syntax-and-terminology)
+section, below.
+
+We propose a function-parameter declaration syntax where a dot (`.`)
+followed by a parameter name forms a _designator_, a name with semantic
+significance that must be the same in every declaration of the function and is
+used to identify the parameter at function invocation. There would be no change
+to the meaning of parameter names _not_ preceded by a dot:
+
+```cpp
+template <class Shape, class Transform>
+Shape munge(const Shape&     shape,       // normal parameter
+            const Transform& .transform,  // `transform` is a designator
+            .,                            // separator, see below
+            double           .scale     = 1.0,
+            const Point&     .translate = {0.0, 0.0});
+```
+
+The argument-passing syntax at the call site resembles designated member
+initialization for aggregate types ([dcl.init.aggr]{.sref}). The `munge`
+function would be called like this:
+
+```cpp
+// Munge `myShape` using the specified lambda and scale by 1.5. The translation
+// is not specifed, so the default translation is used.
+auto newShape = munge(myShape, // bound to first parameter (`shape`)
+                      .transform = [](Shape& s){ ... },
+                      .scale     = 1.5);
+```
+
+The single-dot psuedo-parameter between `.transform` and `.scale` is used to
+separate positional parameters form non-positional parameters. Arguments can be
+bound to positional parameters with or without a designator whereas positional
+arguments can be specified only by using the designated-argument syntax. Thus,
+the following invocation of `munge` is equivalent to the one above.
+
+```cpp
+auto newShape = munge(myShape,              // bound to `shape`
+                      [](Shape& s){ ... },  // bound to `transform`
+                      .scale     = 1.5);    // `.scale =` is required
+```
+
+
+# Motivating Use Cases
+
+Consider a `makeWindow` function that creates a rectangular user-interface
+window. Of its 6 parameters, only the width and height are required. If the
+top-left is not specified, the window manager will place the window on the
+screen according to some algorithm. If the background and foreground colors are
+not specified, white and black are used, respectively:
+
+```cpp
+WinHandle makeWindow(int width,                       int height,
+                     int left         = INT_MIN,      int top = INT_MIN,
+                     Color background = Color::white, Color foreground = Color::black);
+```
+
+Although some might consider the interface to be too large, it is at worst
+mildly so. Although the interface is straightforward, it is nevertheless
+inconvenient and error prone to use. A number of problems with this interface
+are detailed below, followed by a description of how each is improved by using
+designated parameters as proposed in this paper.
+
+## Less Error Prone
+
+The first 4 parameters all have type `int`. It is thus very easy to supply
+arguments in the wrong order or even assume the wrong meaning:
+
+::: cmptable
+
+### Without Designated Parameters
+
+```cpp
+int top   = 100,   left  = 150;
+int height = 1100, width = 1000;
+
+// BUG, but compiles
+auto w = makeWindow(top, left, height, width);
+```
+
+### With Designated Parameters
+
+```cpp
+int top    = 100,  left  = 150;
+int height = 1100, width = 1000;
+
+// OK
+auto w = makeWindow(.top=top,       .left=left,
+                    .height=height, .width=width);
+```
+
+---
+
+```cpp
+int top    = 100,  left  = 150;
+int bottom = 1100, right = 1250;
+
+// BUG, but compiles
+auto w = makeWindow(top, left, bottom, right);
+```
+
+```cpp
+int top    = 100,  left = 150;
+int bottom = 1100, right = 1250;
+
+// Error: No such parameters `.bottom` and `.right`
+auto w = makeWindow(.top=top,       .left=left,
+                    .bottom=bottom, .right=right);
+```
+:::
+
+For some functions, the "obvious" order of arguments is not the correct
+order. In the first case, we often talk about the "top-left corner", but
+traditionally the x coordinate (left) comes first.  Moreover it is
+counterintuitive to put the width and height before the top and left, but the
+author of `makeWindow` had no choice because mandatory arguments must always
+come before optional ones. The designated arguments can appear in any order, so
+the version on the right yields the expected result.
+
+In the second case, the arguments are not only in the wrong order, but are
+ascribed the wrong meaning. Again, the code looks correct and compiles
+successfully, but result is not what is desired. The version on the right will
+flag the error at compile time, as the misunderstanding results in a mismatch
+between the argument designator and parameter designator.
+
+## More Convenient
+
+Default arguments are a convenience feature, but to supply a non-default value
+for one parameter, the caller must provide non-default values for all preceding
+parameters. In the example below, the `INT_MIN` arguments on the left are pure
+noise and make the call harder to write and read. The code on the right is
+clean and minimal.
+
+::: cmptable
+
+### Without Designated Parameters
+
+```cpp
+auto w = makeWindow(w, h, INT_MIN, INT_MIN, Color::grey50);
+```
+
+### With Designated Parameters
+
+```cpp
+auto w = makeWindow(w, h, .foreground = Color::grey50);
+```
+
+:::
+
+
+## Self Documenting
+
+Most code is read more often than it's written. Reading code, e.g., during a
+code review, is more convenient when the reader doesn't need to look up the
+parameter list for many functions.
+
+::: cmptable
+
+### Without Designated Parameters
+
+```cpp
+// What are all those numbers?
+auto w = makeWindow(1000, 1500, 10, 20);
+```
+
+### With Designated Parameters
+
+```cpp
+// Obvious meaning
+auto w = makeWindow(.width = 1000, .height = 1500,
+                    .left  = 10,   .top = 20);
+```
+
+:::
+
+Designated arguments reduce the cognitive load for both reading and writing
+functions having as few as two parameters, with an exponentially bigger benefit
+on each additional parameter.
+
+## Simpler Code Evolution and Fewer Overloads
+
+Consider this function, whose parameter list ends with a variadic parameter
+pack:
+
+```cpp
+template <class T = int, class... Args>
+void calculate(T& x = {}, Args&&... args);
+```
+
+A later version of the library adds the ability to specify an optional
+`ThreadPool` object that `calculate` can use to speed up computation. There is
+no place to put the `ThreadPool` parameter without breaking the API, either in
+the original function or by adding an overload. One solution, used in a few
+places in the standard library, is to create a tag type at namespace scope that
+precedes the `ThreadPool` parameter, where the tag type is expected never to be
+used for any other purpose. This technique is necessitates a new overload for
+each updated function and is a clunky workaround for the lack of designated
+parameters in the language. Designated parameters, conversely, allow us to
+cleanly add the `ThreadPool` parameter on the existing function without
+creating overload ambiguities:
+
+::: cmptable
+
+### Without Designated Parameters
+
+```cpp
+// Define tag type
+struct ThreadPool_arg_t {
+  explicit ThreadPool_arg_t() = default;
+};
+inline constexpr ThreadPool_arg_t ThreadPool_arg{};
+
+template <class T = double, class... Args>
+T calculate(T& x = {}, Args&&... args);
+
+template <class T = double, class... Args>
+T calculate(ThreadPool_arg_t, ThreadPool& threadpool,
+            T& x = {}, Args&&... args);
+
+auto r1 = calculate(19.4, "encode", 1.0);
+auto r2 = calculate(ThreadPool_arg, myThreadPool,
+                    19.4, "encode", 1.0);
+```
+
+### With Designated Parameters
+
+```cpp
+
+
+
+
+
+
+
+
+
+template <class T = double, class... Args>
+T calculate(T& x = {}, Args&&... args, .,
+            ThreadPool& .threadpool = defaultThreadPool);
+
+auto r1 = calculate(19.4, "encode", 1.0);
+auto r2 = calculate(19.4, "encode", 1.0,
+                    .threadpool = myThreadPool);
+```
+
+:::
+
+## More Expressive Overloading
+
+Consider a `Point` class representing a point in 2-dimensional space. A `Point`
+can be constructed using either Cartesian coordinates or polar coordinates.  In
+both cases, the constructor take two parameters of type `double`. Designated
+parameters allow the two constructors to coexist without using a disambiguating
+tag type:
+
+::: cmptable
+
+### Without Designated Parameters
+
+```cpp
+class Point
+{
+public:
+  struct polar_coord_t { explicit polar_coord_t() = default; };
+  static inline constexpr polar_coord_t polar_coord{};
+
+  Point(double x, double y);
+  Point(polar_coord_t, double radius, double angle);
+};
+
+Point p1(4.0, 3.0);
+Point p2(Point::polar_coord, 5.0, 0.6435);
+```
+
+### With Designated Parameters
+
+```cpp
+class Point
+{
+public:
+
+
+
+  constexpr Point(double .x, double .y);
+  constexpr Point(., double .radius, double .angle);
+};
+
+Point p1(4.0, 3.0); // = Point p1(.x=4.0, .y=3.0);
+Point p2(.radius=5.0, .angle=0.6435);
+```
+
+:::
+
+## More Expressive Generic Programming
+
+Although some version of designated arguments have been proposed several times
+(see the [Previous Attempts](#previous-attempts) section) for promoting
+code-clarity and preventing errors, the proximate reason that the authors are
+revisiting this topic at this time is for generic programming. In particular,
+it is often desirable to pass a contextual argument through multiple levels of
+generic code to a function or constructor that needs it. Examples include
+allocators, logging streams, and thread pools. Currently, passing such a
+parameter requires rigid parameter-order rules that might conflict with one
+another. Typically a function having one of these cross-cutting parameters must
+put that parameter last (which conflicts with variadic parameters) or first
+(which makes it difficult to give it a default argument value). Both
+conventions can cause conflicts if two or more of these environmental
+parameters are needed on the same function. All of those issues are obviated
+through the use of designated parameters:
+
+```cpp
+template <class... Args, class Allocator = std::allocator<>>
+class Service {
+public:
+  Service(int x, Args&&... args, .,
+          Logger& .logger      = global_logger(),
+          Allocator .allocator = {});
+
+  void doSomething();
+};
+
+template <class S, class... CtorArgs>
+void func(CtorArgs&& ctorArgs)
+{
+  Logger myLogger;
+
+  // Generically pass a logger to the `S` constructor.
+  S svc(std::forward<CtorArgs>(ctorArgs)..., .logger = myLogger)
+  svc.doSomething();
+}
+```
+
+In the above example, the only thing `func` needs to know to pass a logger to
+the `S` constructor is that the constructor takes a designated parameter named
+"logger." Some of the enhancements described in the
+[Possible Enhancements](#possible-enhancements) section would make even this
+knowledge unnecessary.
+
+A planned future proposal built on top of this designated-parameter proposal
+would expand on this feature by allowing default arguments to get their values
+from the caller's environment, replacing some current (unsafe) uses of global
+and thread-local variables, while reducing the noise of passing arguments down
+an arbitrarily deep function-call hierarchy.
+
+
+# Nomenclature
+
+We introduce two new terms for describing function parameters:
+
+- **Designated** - Indicates that the parameter's name applies not only to a
+  local-variable declaration, but to a semantically significant name used to
+  identify the matching argument at the call site. Designated parameters are
+  sometimes refered to as _named_ parameters, but the term, _named_, does not
+  distinguish between local names and semantically significant designators.
+- **Positional** - Indicates that the position of the parameter or argument in
+  the overall list of parameters is meaningful. C++26 parameters and arguments
+  are always positional.
+
+In this proposal, a function parameter can be
+
+1. Undesignated and positional (the only option in C++26)
+2. Designated and nonpositional
+3. Designated and positional
+
+## Designated Positional Parameters: Divergence in Co-author Opinions
+
+One of the co-authors of this paper, Joshua Berne, is not sure that the third
+combination is needed for a successful feature, while the other co-author,
+Pablo Halpern, is convinced that it is needed to simplify wide adoption in
+existing libraries. For example `unordered_map` has the following
+`initializer_list` constructor (`constexpr` omitted for brevity):
+
+```cpp
+unordered_map(initializer_list<value_type> il,
+              size_type                    n   = @_imp defined_@,
+              const hasher&                hf  = hasher(),
+              const key_equal&             eql = key_equal(),
+              const allocator_type&        a   = allocator_type());
+```
+
+Ideally, `n`, `hf`, and `eql` could be specified independently (`a` _can_ be
+specified independently by way of additional overloads), but it is not possible
+to specify `hf` without specifying `n` and it is not possible to specify `eql`
+without specifying both `n` and `hf`. Designated arguments would allow each of
+those arguments to be specified separately (and in any order) but, to retain
+backward compatibility, it must still be possible to construct an
+`unordered_map` using positional arguments alone.
+
+If designated parameters can also be positional, then it is necessary only to
+assign designators to each optional parameter. If, however, designated
+parameters are disjoint from positional parameters, 4 new overloads would be
+required to realize the full potential of designated parameters without
+creating an overload ambiguity with the constructor having no designated
+parameters:
+
+::: cmptable
+
+### With Designated Positional Arguments
+
+```cpp
+unordered_map(initializer_list<value_type> il,
+              size_type             .min_buckets = @_imp-defined_@,
+              const hasher&         .hash        = hasher(),
+              const key_equal&      .equal       = key_equal(),
+              const allocator_type& .allocator   = allocator_type());
+```
+
+### Without Designated Positional Arguments
+
+
+```cpp
+unordered_map(initializer_list<value_type> il,
+              size_type             n   = @_imp-defined_@,
+              const hasher&         hf  = hasher(),
+              const key_equal&      eql = key_equal(),
+              const allocator_type& a   = allocator_type());
+unordered_map(initializer_list<value_type> il,
+              size_type             .min_buckets,
+              const hasher&         .hash        = hasher(),
+              const key_equal&      .equal       = key_equal(),
+              const allocator_type& .allocator   = allocator_type());
+unordered_map(initializer_list<value_type> il,
+              const hasher&         .hash,
+              const key_equal&      .equal       = key_equal(),
+              const allocator_type& .allocator   = allocator_type());
+unordered_map(initializer_list<value_type> il,
+              const key_equal&      .equal,
+              const allocator_type& .allocator   = allocator_type());
+unordered_map(initializer_list<value_type> il,
+              const allocator_type& .allocator);
+```
+
+:::
+
+For now, we will explore a design space that includes designated positional
+parameters, so that we can find any difficulties and possible was of mitigating
+them. A straw-man syntax for separating positional parameters from
+nonpositional parameters within a declaration is a single dot pseudo-argument:
+
+```cpp
+// `func` has positional designated parameters `x` and `y` and
+// nonpositional designated parameters `a` and `b`.
+void func(int .x, int .y, ., float .a, std::string .b = {});
+```
+
+# Parameter and Argument Order
+
+Parameters in a function declaration must appear in the following order (any or
+all of the following may be absent):
+
+1. Undesignated positional parameters without default arguments
+2. Designated positional parameters without default arguments
+3. Designated and undesignated positional parameters with default arguments
+4. An undesignated variadic parameter (with ellipsis)
+5. Designated nonpositional parameters, preceded by (in this straw man syntax),
+   a pseudo-parameter consisting of a single dot (`.`).
+
+For positional parameters, the order of types and position of designators is
+significant; two declarations that differ in the order of positional parameters
+declare different functions. For nonpositional parameters, order is not
+significant; two declarations that differ only in the order of nonpositional
+parameters refer to the same function.
+
+Examples:
+
+```cpp
+void f1(int x, int y = 0, ., double .scale = 1.0);
+
+template <class... V>
+void f2(int x, int .y = 0, int z = 0, V&&...v, ., int .origin, int .offset = 0);
+```
+
+When calling a function, undesignated arguments must appear before first, in
+positional order, followed by designated arguments. The relative ordering of
+designated arguments is not significant.
+
+Examples:
+
+```cpp
+f1(9, 8, .scale = 2.0);  // All arguments are explicitly specified
+f1(9, .scale = 1.5);     // y = 0 by default
+f1(9, 8);                // scale = 1.0 by default
+f1(9, .scale = .5, 8);   // Ill formed: undesignated arg after designated arg
+
+// x = 1, y = 2, z = 3, v...[0] = 'd', v...[1] = 0.4, origin = 0, offset = 0
+f2(1, 2, 3, 'd', 0.4, .origin = 0);
+
+// x = 1, y = 2, z = 0, sizeof...(v) = 0, origin = 0, offset = 1
+f2(1, .origin = 0, .y = 2, .offset = 1);
+
+f2(1, 2, 3, 'd', 0.4);  // Overload failure: no value specified for origin
+
+// Ill-formed: undesignated arg after designated arg
+f2(1, .y = 2, 3, 'd', 0.4, .origin = 0);
+```
+
+# Interaction with Overload Resolution
+
+Parameter designators are part of a function's signature (and thus its type,
+see [Interaction with Type System](#interaction-with-type-system)).  It is thus
+possible to overload solely on designator names:
+
+```cpp
+class Stream
+{
+public:
+  enum class Mode { READ, WRITE, APPEND };
+
+  ...
+  // distinct overloads of `open`
+  int open(Mode .mode, const std::string .filename); // overload #1
+  int open(Mode .mode, const std::string .url);      // overload #2
+  ...
+};
+```
+
+Changes in overload resolution ([over.match]{.sref}) should be
+modest, affecting mostly the first step of identifying viable functions in
+section [over.match.viable]{.sref}. Rather than specifying this step based on
+the number of arguments, we specify an algorithm for matching each argument to
+a corresponding function parameter.
+
+For a function call having _N_ positional arguments PA~i~, for integer _i_ in
+the range 1..._N_, followed by _M_ designated arguments, DA~d~, where each _d_
+is a designator name (not an integer), arguments are matched to parameters as
+follows.
+
+For each nondesignated argument, PA~i~,
+
+- if a positional parameter PP~i~ exists, then PA~i~ matches PP~i~;
+- otherwise, if there is a variadic parameter, then PA~i~ matches the variadic
+  parameter;
+- otherwise, PA~i~ has no match.
+
+For each designated argument, DA~d~,
+
+- if a designated parameter DP~d~ exists, then DA~d~ matches DP~d~;
+- otherwise, if the first unmatched positional parameter has type (possibly
+  cvref-qualified) `T`, where `T` is a deduced template parameter, then DA~d~
+  matches that positional parameter;
+- otherwise, if there is a variadic parameter of type (possibly
+  cvref-qualified) `Args...`, where `Args` is a deduced template parameter
+  pack, then DA~d~ matches that variadic parameter (see
+  [Interaction with Parameter Packs](#interaction-with-parameter-packs),
+  below);
+- otherwise, DA~d~ has no match.
+
+To be a viable function,
+
+- each argument must match exactly one parameter, and
+- each non-variadic parameter must match exactly one argument or else match no
+  arguments and have a default argument.
+
+Note that a designated positional parameter can be matched either by position
+or by designator, but if it matches more than one distinct argument, the
+function would be nonviable.
+
+The specification for the best viable function in section
+[over.match.best]{.sref} would be modified to refer to the argument-parameter
+matches determined by the algorithm above instead of to the *i^th^* argument
+and *i^th^* parameter. Otherwise, there should be few other changes to the rest
+of overload resolution section ([over.match]{.sref}).
+
+As in C++26, overload resolution can result in an ambiguity at the call site:
+
+```cpp
+void f()
+{
+  Stream s;
+
+  s.open(Stream::Mode::READ, .filename = "myinput.txt");    // OK
+  s.open(Stream::Mode::READ, "https::/isocpp.org/myinput"); // Error: ambiguous
+}
+```
+
+TBD: Need examples of overload resolution, including examples of errors where
+positional argument and a designated argument refer to the same parameter.
+
+# Interaction with Parameter Packs
+
+Consider a function template that simply preforms an action before and after
+calling an invocable entity, `f`, with supplied arguments:
+
+```cpp
+template <class F, class... Args>
+auto verbose_call(F&& f, Args&&... args) -> decltype(auto) {
+  std::cout << "Prologue\n";
+  decltype(auto) ret = std::forward<F>(f)(std::forward<Args>(args)...);
+  std::cout << "Epilogue\n";
+  return ret;
+}
+```
+
+It is extremely desirable for the above template, which is valid C++26, to
+continue to work unchanged in the world of designated parameters. Given the
+following declaration and call:
+
+```cpp
+void func(int, ., const char* .name);
+verbose_call(func, 15, .name="Fred");
+```
+
+We would want the invocation of f within `verbose_call` to expand to something
+equivalent to the following.
+
+```cpp
+  decltype(auto) ret = std::forward<void (&)(int, const char* .name)>(func)(
+    std::forward<int>(15), .name=std::forward<const char (&)[5]>("Fred"));
+```
+
+In the
+[Interaction with Overload Resolution](interaction-with-overload-resolution)
+section, above, the argument-to-parameter matching algorithm matches any
+designated argument to the variadic template parameter if there is no
+corresponding designated parameter.  Thus, `.name="Fred"` gets mapped to the
+`args` parameter pack. The question then becomes, how is the designator
+forwarded to further in the call tree?
+
+One possible rule would be for the designator to follow the
+argument, i.e., the last argument to `func` starts with `.name=` because the
+designator is associated with the last argument of the parameter pack. This
+rule is deficient, however, when the argument is not present, as in the case of
+type traits or concepts:
+
+```cpp
+template <class F, class... Args>
+  requires std::invocable<F, Args...>
+auto verbose_call(F&& f, Args&&... args) -> decltype(auto) { ... }
+```
+
+To make the `invocable` concept work, `Args` must describe not only the type,
+but also the designator (if any) associated with each argument at the point of
+instantiation.  What we propose is to expand the type system with _designator
+qualifiers_. In the expression, `verbose_call(func, 15, .name="Fred")`, the third
+argument has type `const char (&)[5]`, with `.name` is its designator
+qualifier. If we were to reify the designator qualifier as something that can
+be uttered directly by the programmer, we might say that `decltype(.length =
+5)` has type `int.length` or, more generally, that `decltype(.@_name_@ =
+@_expr_@)` has type `decltype(@_expr_@).@_name_@`.  Such reification is
+probably not essential, but it does make designated parameters easier to talk
+about and it is useful to be able to designator-qualified type directly, e.g.,
+to store an argument list in a `tuple` (`tuple<int.x, int.y>`), to express a
+type trait (`is_constructible_v<T, float.name>`), etc.. Given this approach,
+the invocation of f within `verbose_call` would forward the `.name` argument as
+a designator-qualified array of `const char`:
+
+```cpp
+  decltype(auto) ret = std::forward<void (&)(int, const char* .name)>(func)(
+    std::forward<int>(15), std::forward<const char (&.name)[5]>("Fred"));
+```
+
+The name-matching rules in the previous section
+([Interaction with Overload Resolution](#interaction-with-overload-resolution))
+should therefore be modified such that a designated parameter's type is
+expressed as being designator-qualified and would match a designated parameter
+having the same designator.
+
+There are no conversions between a type and its designator-qualified variant. A
+designator `.d` is appended to the type of an expression `e` of type `T` using
+the expression `.d = e`. Conversely, an expression `de` of type `T.d` is
+stripped of its designator by binding it to a parameter with designator `.d`.
+We might also allow the same rules to apply to `auto` variables:
+
+```cpp
+void g()
+{
+  auto di = (.x = 5);  // decltype(di) is int.x
+  auto .x = di;        // decltype(x) = int
+  assert(x == 5);
+}
+```
+
+The only implicit conversion-like binding is that an expression without a
+designator can bind to a positional parameter with a designator.
+
+A value of designator-qualified type could also be extracted from a parameter
+pack using the designator as a pack index:
+
+```cpp
+auto v = args...[.x];
+```
+
+Many of the semantics of designated parameters and designated arguments flow
+naturally from the introduction of designator-qualified types and obviate
+special-case handling in the Core Language, the Standard Library, and in
+compiler implementations.  Most generic code will continue to yield expected
+results without modification.  For example:
+
+```cpp
+// `forward_as_tuple` returns a `tuple` instantiated with two designator-qualified types.
+// `p.second` is initialized with arguments `.value=x, .offset=-1`.
+std::pair<int, W> p(std::piecewise_construct, 99
+                    std::forward_as_tuple(.value=x, .offset=-1));
+
+// Yields `tuple<const char *, int.angle, double.radius>`
+auto t = std::make_tuple("hello", .angle=30, .radius=2.5);
+
+// Invokes `func("hello", .angle=30, .radius=2.5)`
+apply(func, t);
+```
+
+# Interaction with Type System
+
+Designated parameters are encoded in the type system. Because
+designator-qualified types are part of a function's signature, a function's
+type naturally includes the designators for its parameters.  Similarly, a
+function pointer can be declared with designators:
+
+```cpp
+int (*fp1)(int x, int .value);
+```
+
+We can introduce a new rule whereby a pointer to function having
+designated positional parameters can be converted to a pointer to function
+having the same positional parameters, but where some of them are not
+designated:
+
+```
+int (*fp2)(int x, int v) = fp1;  // implicit conversion
+```
+
+For overload resolution, this conversion would have the rank of either a
+promotion or a standard conversion.
+
+TBD: How much more needs to be said about interaction with the type system?
+
+# Interaction with Reflection
+
+TBD
+
+# Possible Enhancements
+
+TBD: Each of the enhancements listed here needs explanation.
+
+- Special designated arguments that override same-named arguments in a
+  parameter pack.
+
+- Special designated arguments that are ignored on function calls that don't
+  have such a designated parameter.
+
+- Variadic designated parameters
+
+- Designated template parameters (i.e., `template <class T, class .Allocator>`)
+
+# Impact on the Standard Library
+
+TBD: We would want to at least enhance _uses-allocator construction_ to
+recognize parameters of the form `Allocator .allocator`.  We might also want to
+tackle some cases of tagged parameters; providing a prettier alternative by way
+of new overloads.
+
+# ABI Considerations
+
+TBD: We anticipate little or no impact on ABI for existing code.
+
+# Alternative Syntax and Terminology
+
+**Alternative Nomenclature**: Use the term _label_ instead of _designator_
+(similarly _labeled parameter_, _labeled argument_, _label-qualified type_).
+
+**Alternative designator syntax**: `void func(T t:, U (&f:)());` instead of
+`void func(T .t, U (&.f)());` and `func(t : expr1, f : expr2)` instead of
+`func(.t = expr1, .f = expr2)` (and similarly `T:name` instead of `T.name` for
+a designator-qualified type).  Advantage: in the call syntax, the argument name
+is not preceded by a gratuitous dot and the argument does not look like an
+assignment expression. _Editorial note: Pablo prefers this syntax.  The term_
+label _is probably better for this syntax_.
+
+**Alternative separator syntax**: The straw-man syntax for separating
+positional from nonpositional parameters is arbitrary.  Alternatives to
+consider would be using a different delimiter, e.g., `/` or `|` instead of
+`,.,`; grouping nonpositional parameters in square or curly braces; or
+indicating positional and nonpositional designated parameters with a different
+tokens sequence, e.g., a `.^` prefix or `^:` suffix for designated parameters
+that are also positional.
+
+# Previous Attempts at Designated Arguments
+
+## Language Proposals
+
+TBD: This section is incomplete.  In particular, we need to look up the
+discussion notes on each proposal and see why the committee rejected them.
+
+[@N0060] Keyword Parameters in C++
+
+[@N4172] Named Arguments ((discussion notes)[http://wiki.edg.com/bin/view/Wg21urbana-champaign/FunctionFacilities#N4172_Named_Function_Arguments])
+
+> Both of these papers propose using the argument name from the function
+> declaration as the name of the argument that can be used at the call
+> site. These proposals can produce inconsistent results when functions are
+> declared more than once in a program and the declarations do not use the same
+> parameter names. It has long been true (even in when N0050 was proposed in
+> 1991), going back to C++'s roots in C, that parameter names in function
+> declarations had no semantic significance, except in the function's
+> definition, and it was not practical to suddenly make them significant.
+> Moreover, the names of parameters in the Standard Library are not themselves
+> standard, so such use of named parameters is not portable.
+
+[@P0671R2] Self-explanatory Function Arguments (see References for more links)
+
+> This proposal uses a new syntax for naming parameters but does not permit
+> re-ordering arguments at the call site. Although it would have made client
+> code easier to read and reduce the chance of certain errors, it falls short
+> of providing the many benefits of true designated parameters.  Ultimately,
+> this proposal would have improved compiler diagnostics, but would not have
+> increased the expressiveness of the language.
+
+[@P1229R0] Labelled Parameters [British spelling of labeled]
+
+> This paper is the most similar to our proposal.  After a garden-path walk
+> through an unworkable library solution, it proposes putting a label before
+> the parameter declaration and using `label : expr` for arguments.  For
+> non-positional parameters, `explicit` is used ahead of the label, which is
+> interesting. It also re-orders the parameter naming so that you would write
+> `name : type` instead of `type .name` or `type name:`, which is a gratuitous
+> change to the declaration syntax.  Ultimately, it is not a well-written paper
+> and is very incomplete. It does not go into detail about parameter packs
+> (despite saying that it is "compatible with `std::forward`ing."),
+> overloading, or integration with the type system.
+
+[@P3405R0] Out-of-order designated initializers
+
+> This paper does not propose designated parameters _per se_, but does relax
+> the restriction on the ordering of designated initializers for aggregates,
+> making the use of designated initializers more suitable as a substitute for
+> true designated parameters. It does nothing for solving the other problems
+> with designated initializers, however, including their not working with
+> template argument deduction.
+
+**In Summary**, none of these previous attempts was a complete proposal that
+addressed the full range of issues required to integrate a designated
+parameters feature into modern C++.
+
+## Library Workaround Using Designated Aggregate Initializers
+
+One technique used to get the _illusion_ of designated parameters uses a
+`struct` to aggregate a function's parameters. Rather than having _n_
+parameters, the function has a single parameter of a custom `struct` type
+having _n_ members:
+
+```cpp
+// function-argument struct
+struct MakeWindowParams {
+  int width;
+  int height;
+  int left         = INT_MIN;
+  int top          = INT_MIN;
+  Color background = Color::white;
+  Color foreground = Color::black;
+};
+
+// function prototype
+WindowHandle = MakeWindow(MakeWindowParams&& args);
+
+// function call
+auto win = MakeWindow({ .width = wd, .height = ht, .foreground = fg });
+```
+
+**Shortcomings**
+
+- Every function potentially needs a custom struct.
+- The caller cannot provide arguments other than in the order declared,
+  although [@P3405R0] would change that, if adopted.
+- Does not work with template argument deduction.
+- For default-constructible parameter types, there is no way to force the
+  caller to supply a value. For example, in the declaration of `MakeWindow`
+  above, we might want to force the caller to specify `width` and `height`, but
+  there is no way to express that with this idiom.
+
+
+---
+references:
+  - id: N0060
+    citation-label: N0060 (X3J16_91-0127)
+    author:
+      - name: Roland Hartinger
+      - name: Andreas Schmidt
+      - name: Erwin Unruh
+    title: "Keyword parameters in C++"
+    date: 1991
+    URL: https://www.open-std.org/JTC1/SC22/WG21/docs/papers/1991/WG21%201991/X3J16_91-0127%20WG21_N0060.pdf
+
+  - id: N0088R1
+    citation-label: N0088R1 (X3J16_92-0010R1)
+    author: Bruce Eckle
+    title: "Analysis of C++ Keyword Arguments"
+    date: 1992
+    URL: https://www.open-std.org/jtc1/sc22/wg21/docs/papers/1992/WG21%201992/X3J16_92-0010R1%20WG21_N0088R1.pdf
+---


### PR DESCRIPTION
This PR introduces a `side-channels` directory containing two documents: `Side-channels_proposal-hierarchy.md` and `named-parameters.md`, which are a roadmap and first step, respectively, towards allocators in the C++ language. It also includes a minimal simulation of designated parameters, proving the viability of a type-based approach to forwarding and overloading on designated arguments.